### PR TITLE
Update image gen recipes

### DIFF
--- a/src/comfyui-base/Dockerfile
+++ b/src/comfyui-base/Dockerfile
@@ -17,7 +17,7 @@ RUN rm /etc/supervisor/supervisord/conf.d/syncthing.conf
 # is fully asyncronous by default, and has no convenient way to retrieve 
 # generated images. If you're adding a custom worker, you'll need to copy it in here.
 # COPY comfyui-api .
-ARG api_version=1.4.0
+ARG api_version=1.4.1
 ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
 RUN chmod +x comfyui-api
 

--- a/src/dreamshaper8-comfyui/Dockerfile
+++ b/src/dreamshaper8-comfyui/Dockerfile
@@ -1,6 +1,6 @@
 # We're going to use this verified comfyui image as a base
 ARG comfy_version=0.2.0
-ARG api_version=1.4.0
+ARG api_version=1.4.1
 FROM saladtechnologies/comfyui:comfy${comfy_version}-api${api_version}-base
 
 ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints

--- a/src/dreamshaper8-comfyui/container-group.json
+++ b/src/dreamshaper8-comfyui/container-group.json
@@ -2,23 +2,34 @@
   "name": "comfyui-dreamshaper8",
   "display_name": "comfyui-dreamshaper8",
   "container": {
-    "image": "saladtechnologies/comfyui:comfy0.2.0-api1.4.0-dreamshaper8",
+    "image": "saladtechnologies/comfyui:comfy0.2.0-api1.4.1-dreamshaper8",
     "resources": {
       "cpu": 4,
       "memory": 12288,
-      "gpu_classes": ["cb6c1931-89b6-4f76-976f-54047320ccc6"],
+      "gpu_classes": [
+        "ed563892-aacd-40f5-80b7-90c9be6c759b"
+      ],
       "storage_amount": 1073741824
     },
-    "command": []
+    "command": [],
+    "priority": "high"
   },
+  "autostart_policy": true,
+  "restart_policy": "always",
   "replicas": 3,
   "networking": {
     "protocol": "http",
     "port": 3000,
-    "auth": false
+    "auth": false,
+    "load_balancer": "round_robin"
   },
   "readiness_probe": {
-    "http": { "path": "/ready", "port": 3000, "scheme": "http", "headers": [] },
+    "http": {
+      "path": "/ready",
+      "port": 3000,
+      "scheme": "http",
+      "headers": []
+    },
     "initial_delay_seconds": 0,
     "period_seconds": 2,
     "timeout_seconds": 2,

--- a/src/dreamshaper8-comfyui/get-openapi-spec
+++ b/src/dreamshaper8-comfyui/get-openapi-spec
@@ -1,0 +1,60 @@
+#! /usr/bin/bash
+set -e
+
+image="saladtechnologies/comfyui"
+usage="Usage: ./get-openapi-spec --comfy <comfy-version> --api <api-version> [--image <image> default: $image]"
+
+model_name="dreamshaper8"
+while [ "$1" != "" ]; do
+  case $1 in
+  --comfy)
+    shift
+    comfy_version=$1
+    ;;
+  --api)
+    shift
+    api_version=$1
+    ;;
+  --image)
+    shift
+    image=$1
+    ;;
+  *)
+    echo $usage
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+if [ -z "$comfy_version" ] || [ -z "$api_version" ]; then
+  echo $usage
+  exit 1
+fi
+
+tag="comfy$comfy_version-api$api_version-$model_name"
+
+# Start the server
+echo "Starting server..."
+docker run --rm --gpus all \
+-p 3000:3000 \
+--name comfyui-$model_name \
+-e MARKDOWN_SCHEMA_DESCRIPTIONS="false" \
+$image:$tag &
+
+function healthcheck {
+  curl -s http://localhost:3000/health > /dev/null
+}
+
+until healthcheck; do
+  echo "Waiting for server to start..."
+  sleep 1
+done
+
+# Download the spec to a file called openapi.json
+echo "Downloading OpenAPI spec..."
+curl -s http://localhost:3000/docs/json | jq . > openapi.json
+
+# Stop the server
+echo "Stopping server..."
+docker stop comfyui-$model_name

--- a/src/dreamshaper8-comfyui/openapi.json
+++ b/src/dreamshaper8-comfyui/openapi.json
@@ -1,10 +1,17 @@
 {
   "openapi": "3.0.0",
-  "info": { "title": "Comfy Wrapper API", "version": "1.4.0" },
-  "components": { "schemas": {} },
+  "info": {
+    "title": "Comfy Wrapper API",
+    "version": "1.4.1"
+  },
+  "components": {
+    "schemas": {}
+  },
   "paths": {
     "/health": {
       "get": {
+        "summary": "Health Probe",
+        "description": "Check if the server is healthy",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -13,10 +20,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["healthy"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "healthy"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -29,10 +49,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["not healthy"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "not healthy"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -43,6 +76,8 @@
     },
     "/ready": {
       "get": {
+        "summary": "Readiness Probe",
+        "description": "Check if the server is ready to serve traffic",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -51,10 +86,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["ready"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ready"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -67,10 +115,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["not ready"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "not ready"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -81,6 +142,8 @@
     },
     "/models": {
       "get": {
+        "summary": "List Models",
+        "description": "List all available models. This is from the contents of the models directory.",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -91,59 +154,105 @@
                   "properties": {
                     "checkpoints": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "clip": { "type": "array", "items": { "type": "string" } },
+                    "clip": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "clip_vision": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "configs": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "controlnet": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "diffusers": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "diffusion_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "embeddings": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "gligen": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "hypernetworks": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "loras": { "type": "array", "items": { "type": "string" } },
+                    "loras": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "photomaker": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "style_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "unet": { "type": "array", "items": { "type": "string" } },
+                    "unet": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "upscale_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "vae": { "type": "array", "items": { "type": "string" } },
+                    "vae": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "vae_approx": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -175,6 +284,8 @@
     },
     "/prompt": {
       "post": {
+        "summary": "Submit Prompt",
+        "description": "Submit an API-formatted ComfyUI prompt.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -187,20 +298,28 @@
                       "type": "object",
                       "properties": {
                         "inputs": {},
-                        "class_type": { "type": "string" },
+                        "class_type": {
+                          "type": "string"
+                        },
                         "_meta": {}
                       },
-                      "required": ["class_type"],
+                      "required": [
+                        "class_type"
+                      ],
                       "additionalProperties": false
                     }
                   },
                   "id": {
                     "type": "string",
-                    "default": "db6da037-3b6f-4a1b-b634-fd62117ed287"
+                    "default": "5b3efdf7-d64d-4298-83a5-599f152ac2c1"
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["prompt"],
+                "required": [
+                  "prompt"
+                ],
                 "additionalProperties": false
               }
             }
@@ -215,28 +334,47 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
+                    "id": {
+                      "type": "string"
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "prompt"],
+                  "required": [
+                    "id",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -249,28 +387,47 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
+                    "id": {
+                      "type": "string"
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "prompt"],
+                  "required": [
+                    "id",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -283,10 +440,16 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": { "type": "string" },
-                    "location": { "type": "string" }
+                    "error": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -297,7 +460,8 @@
     },
     "/workflow/sd1.5/img2img": {
       "post": {
-        "description": "| Field | Type | Description | Default |\n|-|-|-|-|\n| prompt | string | The positive prompt for image generation | - |\n| negative_prompt | string | The negative prompt for image generation | \"text, watermark\" |\n| seed | number | Seed for random number generation | 822683183183174 |\n| steps | number | Number of sampling steps | 15 |\n| cfg_scale | number | Classifier-free guidance scale | 8 |\n| sampler_name | enum (`euler`, `euler_cfg_pp`, `euler_ancestral`, `euler_ancestral_cfg_pp`, `heun`, `heunpp2`, `dpm_2`, `dpm_2_ancestral`, `lms`, `dpm_fast`, `dpm_adaptive`, `dpmpp_2s_ancestral`, `dpmpp_sde`, `dpmpp_sde_gpu`, `dpmpp_2m`, `dpmpp_2m_sde`, `dpmpp_2m_sde_gpu`, `dpmpp_3m_sde`, `dpmpp_3m_sde_gpu`, `ddpm`, `lcm`, `ipndm`, `ipndm_v`, `deis`, `ddim`, `uni_pc`, `uni_pc_bh2`) | Name of the sampler to use | \"euler\" |\n| scheduler | enum (`normal`, `karras`, `exponential`, `sgm_uniform`, `simple`, `ddim_uniform`, `beta`) | Type of scheduler to use | \"normal\" |\n| denoise | number | Denoising strength | 0.8 |\n| checkpoint | enum (`dreamshaper_8.safetensors`) |  | \"dreamshaper_8.safetensors\" |\n| image | string | Input image for img2img | - |\n| width | number | Width of the generated image | 512 |\n| height | number | Height of the generated image | 512 |\n| interpolation | enum (`nearest`) | Interpolation method for image resizing | \"nearest\" |\n| resize_method | enum (`keep proportion`) | Method for resizing the image | \"keep proportion\" |\n| resize_condition | enum (`always`) | Condition for when to resize the image | \"always\" |\n| multiple_of | number | Ensure dimensions are multiples of this value | 0 |\n",
+        "summary": "Image to Image",
+        "description": "Generate an image from another image and a text prompt",
         "requestBody": {
           "content": {
             "application/json": {
@@ -306,7 +470,7 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "default": "c906e348-ec87-4a94-9383-e3118491bbb5"
+                    "default": "954f73a8-467c-4d5e-b7e2-75125035500d"
                   },
                   "input": {
                     "type": "object",
@@ -322,7 +486,7 @@
                       },
                       "seed": {
                         "type": "integer",
-                        "default": 412934701713441,
+                        "default": 354362524833600,
                         "description": "Seed for random number generation"
                       },
                       "steps": {
@@ -396,7 +560,9 @@
                       },
                       "checkpoint": {
                         "type": "string",
-                        "enum": ["dreamshaper_8.safetensors"],
+                        "enum": [
+                          "dreamshaper_8.safetensors"
+                        ],
                         "default": "dreamshaper_8.safetensors"
                       },
                       "image": {
@@ -419,19 +585,25 @@
                       },
                       "interpolation": {
                         "type": "string",
-                        "enum": ["nearest"],
+                        "enum": [
+                          "nearest"
+                        ],
                         "default": "nearest",
                         "description": "Interpolation method for image resizing"
                       },
                       "resize_method": {
                         "type": "string",
-                        "enum": ["keep proportion"],
+                        "enum": [
+                          "keep proportion"
+                        ],
                         "default": "keep proportion",
                         "description": "Method for resizing the image"
                       },
                       "resize_condition": {
                         "type": "string",
-                        "enum": ["always"],
+                        "enum": [
+                          "always"
+                        ],
                         "default": "always",
                         "description": "Condition for when to resize the image"
                       },
@@ -442,12 +614,19 @@
                         "description": "Ensure dimensions are multiples of this value"
                       }
                     },
-                    "required": ["prompt", "image"],
+                    "required": [
+                      "prompt",
+                      "image"
+                    ],
                     "additionalProperties": false
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["input"],
+                "required": [
+                  "input"
+                ],
                 "additionalProperties": false
               }
             }
@@ -462,29 +641,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -497,29 +699,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -530,7 +755,8 @@
     },
     "/workflow/sd1.5/txt2img": {
       "post": {
-        "description": "| Field | Type | Description | Default |\n|-|-|-|-|\n| prompt | string | The positive prompt for image generation | - |\n| negative_prompt | string | The negative prompt for image generation | \"text, watermark\" |\n| width | number | Width of the generated image | 512 |\n| height | number | Height of the generated image | 512 |\n| seed | number | Seed for random number generation | 60688683640 |\n| steps | number | Number of sampling steps | 20 |\n| cfg_scale | number | Classifier-free guidance scale | 8 |\n| sampler_name | enum (`euler`, `euler_cfg_pp`, `euler_ancestral`, `euler_ancestral_cfg_pp`, `heun`, `heunpp2`, `dpm_2`, `dpm_2_ancestral`, `lms`, `dpm_fast`, `dpm_adaptive`, `dpmpp_2s_ancestral`, `dpmpp_sde`, `dpmpp_sde_gpu`, `dpmpp_2m`, `dpmpp_2m_sde`, `dpmpp_2m_sde_gpu`, `dpmpp_3m_sde`, `dpmpp_3m_sde_gpu`, `ddpm`, `lcm`, `ipndm`, `ipndm_v`, `deis`, `ddim`, `uni_pc`, `uni_pc_bh2`) | Name of the sampler to use | \"euler\" |\n| scheduler | enum (`normal`, `karras`, `exponential`, `sgm_uniform`, `simple`, `ddim_uniform`, `beta`) | Type of scheduler to use | \"normal\" |\n| denoise | number | Denoising strength | 1 |\n| checkpoint | enum (`dreamshaper_8.safetensors`) |  | \"dreamshaper_8.safetensors\" |\n",
+        "summary": "Text to Image",
+        "description": "Generate an image from a text prompt",
         "requestBody": {
           "content": {
             "application/json": {
@@ -539,7 +765,7 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "default": "50400830-b9b1-4573-bd02-2ab30801d81d"
+                    "default": "32b5018e-c5dc-4e8e-92d5-bb5ded57a091"
                   },
                   "input": {
                     "type": "object",
@@ -569,7 +795,7 @@
                       },
                       "seed": {
                         "type": "integer",
-                        "default": 15442403858,
+                        "default": 96154286562,
                         "description": "Seed for random number generation"
                       },
                       "steps": {
@@ -643,16 +869,24 @@
                       },
                       "checkpoint": {
                         "type": "string",
-                        "enum": ["dreamshaper_8.safetensors"],
+                        "enum": [
+                          "dreamshaper_8.safetensors"
+                        ],
                         "default": "dreamshaper_8.safetensors"
                       }
                     },
-                    "required": ["prompt"],
+                    "required": [
+                      "prompt"
+                    ],
                     "additionalProperties": false
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["input"],
+                "required": [
+                  "input"
+                ],
                 "additionalProperties": false
               }
             }
@@ -667,29 +901,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -702,29 +959,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }

--- a/src/dreamshaper8-comfyui/workflows/sd1.5/img2img.ts
+++ b/src/dreamshaper8-comfyui/workflows/sd1.5/img2img.ts
@@ -12,6 +12,8 @@ type ComfyNode = z.infer<typeof ComfyNodeSchema>;
 interface Workflow {
   RequestSchema: z.ZodObject<any, any>;
   generateWorkflow: (input: any) => Record<string, ComfyNode>;
+  description?: string;
+  summary?: string;
 }
 
 let checkpoint: any = config.models.checkpoints.enum.optional();
@@ -216,6 +218,8 @@ function generateWorkflow(input: InputType): Record<string, ComfyNode> {
 const workflow: Workflow = {
   RequestSchema,
   generateWorkflow,
+  summary: "Image to Image",
+  description: "Generate an image from another image and a text prompt",
 };
 
 export default workflow;

--- a/src/dreamshaper8-comfyui/workflows/sd1.5/txt2img.ts
+++ b/src/dreamshaper8-comfyui/workflows/sd1.5/txt2img.ts
@@ -12,6 +12,8 @@ type ComfyNode = z.infer<typeof ComfyNodeSchema>;
 interface Workflow {
   RequestSchema: z.ZodObject<any, any>;
   generateWorkflow: (input: any) => Record<string, ComfyNode>;
+  description?: string;
+  summary?: string;
 }
 
 let checkpoint: any = config.models.checkpoints.enum.optional();
@@ -169,6 +171,8 @@ function generateWorkflow(input: InputType): Record<string, ComfyNode> {
 const workflow: Workflow = {
   RequestSchema,
   generateWorkflow,
+  summary: "Text to Image",
+  description: "Generate an image from a text prompt",
 };
 
 export default workflow;

--- a/src/flux1-schnell-fp8-comfyui/Dockerfile
+++ b/src/flux1-schnell-fp8-comfyui/Dockerfile
@@ -1,6 +1,6 @@
 # We're going to use this verified comfyui image as a base
 ARG comfy_version=0.2.0
-ARG api_version=1.4.0
+ARG api_version=1.4.1
 FROM saladtechnologies/comfyui:comfy${comfy_version}-api${api_version}-base
 
 ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints

--- a/src/flux1-schnell-fp8-comfyui/container-group.json
+++ b/src/flux1-schnell-fp8-comfyui/container-group.json
@@ -2,25 +2,34 @@
   "name": "comfyui-flux1-schnell-fp8",
   "display_name": "comfyui-flux1-schnell-fp8",
   "container": {
-    "image": "saladtechnologies/comfyui:comfy0.2.0-api1.4.0-flux1-schnell-fp8",
+    "image": "saladtechnologies/comfyui:comfy0.2.0-api1.4.1-flux1-schnell-fp8",
     "resources": {
       "cpu": 4,
       "memory": 30720,
-      "gpu_classes": ["ed563892-aacd-40f5-80b7-90c9be6c759b"],
+      "gpu_classes": [
+        "ed563892-aacd-40f5-80b7-90c9be6c759b"
+      ],
       "storage_amount": 1073741824
     },
-    "command": []
+    "command": [],
+    "priority": "high"
   },
-  "autostart_policy": false,
+  "autostart_policy": true,
   "restart_policy": "always",
   "replicas": 3,
   "networking": {
     "protocol": "http",
     "port": 3000,
-    "auth": false
+    "auth": false,
+    "load_balancer": "round_robin"
   },
   "readiness_probe": {
-    "http": { "path": "/ready", "port": 3000, "scheme": "http", "headers": [] },
+    "http": {
+      "path": "/ready",
+      "port": 3000,
+      "scheme": "http",
+      "headers": []
+    },
     "initial_delay_seconds": 0,
     "period_seconds": 1,
     "timeout_seconds": 1,

--- a/src/flux1-schnell-fp8-comfyui/get-openapi-spec
+++ b/src/flux1-schnell-fp8-comfyui/get-openapi-spec
@@ -1,0 +1,60 @@
+#! /usr/bin/bash
+set -e
+
+image="saladtechnologies/comfyui"
+usage="Usage: ./get-openapi-spec --comfy <comfy-version> --api <api-version> [--image <image> default: $image]"
+
+model_name="flux1-schnell-fp8"
+while [ "$1" != "" ]; do
+  case $1 in
+  --comfy)
+    shift
+    comfy_version=$1
+    ;;
+  --api)
+    shift
+    api_version=$1
+    ;;
+  --image)
+    shift
+    image=$1
+    ;;
+  *)
+    echo $usage
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+if [ -z "$comfy_version" ] || [ -z "$api_version" ]; then
+  echo $usage
+  exit 1
+fi
+
+tag="comfy$comfy_version-api$api_version-$model_name"
+
+# Start the server
+echo "Starting server..."
+docker run --rm --gpus all \
+-p 3000:3000 \
+--name comfyui-$model_name \
+-e MARKDOWN_SCHEMA_DESCRIPTIONS="false" \
+$image:$tag &
+
+function healthcheck {
+  curl -s http://localhost:3000/health > /dev/null
+}
+
+until healthcheck; do
+  echo "Waiting for server to start..."
+  sleep 1
+done
+
+# Download the spec to a file called openapi.json
+echo "Downloading OpenAPI spec..."
+curl -s http://localhost:3000/docs/json | jq . > openapi.json
+
+# Stop the server
+echo "Stopping server..."
+docker stop comfyui-$model_name

--- a/src/flux1-schnell-fp8-comfyui/openapi.json
+++ b/src/flux1-schnell-fp8-comfyui/openapi.json
@@ -1,10 +1,17 @@
 {
   "openapi": "3.0.0",
-  "info": { "title": "Comfy Wrapper API", "version": "1.4.0" },
-  "components": { "schemas": {} },
+  "info": {
+    "title": "Comfy Wrapper API",
+    "version": "1.4.1"
+  },
+  "components": {
+    "schemas": {}
+  },
   "paths": {
     "/health": {
       "get": {
+        "summary": "Health Probe",
+        "description": "Check if the server is healthy",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -13,10 +20,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["healthy"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "healthy"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -29,10 +49,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["not healthy"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "not healthy"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -43,6 +76,8 @@
     },
     "/ready": {
       "get": {
+        "summary": "Readiness Probe",
+        "description": "Check if the server is ready to serve traffic",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -51,10 +86,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["ready"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ready"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -67,10 +115,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["not ready"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "not ready"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -81,6 +142,8 @@
     },
     "/models": {
       "get": {
+        "summary": "List Models",
+        "description": "List all available models. This is from the contents of the models directory.",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -91,59 +154,105 @@
                   "properties": {
                     "checkpoints": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "clip": { "type": "array", "items": { "type": "string" } },
+                    "clip": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "clip_vision": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "configs": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "controlnet": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "diffusers": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "diffusion_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "embeddings": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "gligen": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "hypernetworks": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "loras": { "type": "array", "items": { "type": "string" } },
+                    "loras": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "photomaker": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "style_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "unet": { "type": "array", "items": { "type": "string" } },
+                    "unet": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "upscale_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "vae": { "type": "array", "items": { "type": "string" } },
+                    "vae": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "vae_approx": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -175,6 +284,8 @@
     },
     "/prompt": {
       "post": {
+        "summary": "Submit Prompt",
+        "description": "Submit an API-formatted ComfyUI prompt.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -187,20 +298,28 @@
                       "type": "object",
                       "properties": {
                         "inputs": {},
-                        "class_type": { "type": "string" },
+                        "class_type": {
+                          "type": "string"
+                        },
                         "_meta": {}
                       },
-                      "required": ["class_type"],
+                      "required": [
+                        "class_type"
+                      ],
                       "additionalProperties": false
                     }
                   },
                   "id": {
                     "type": "string",
-                    "default": "f9ec73b6-e457-4c8c-b250-ae2587160e3c"
+                    "default": "ef479f26-dcd7-48dd-b9ad-5625a12fa49d"
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["prompt"],
+                "required": [
+                  "prompt"
+                ],
                 "additionalProperties": false
               }
             }
@@ -215,28 +334,47 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
+                    "id": {
+                      "type": "string"
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "prompt"],
+                  "required": [
+                    "id",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -249,28 +387,47 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
+                    "id": {
+                      "type": "string"
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "prompt"],
+                  "required": [
+                    "id",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -283,10 +440,16 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": { "type": "string" },
-                    "location": { "type": "string" }
+                    "error": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -297,7 +460,8 @@
     },
     "/workflow/flux/img2img": {
       "post": {
-        "description": "| Field | Type | Description | Default |\n|-|-|-|-|\n| prompt | string | The positive prompt for image generation | - |\n| width | number | Width of the generated image | 1024 |\n| height | number | Height of the generated image | 1024 |\n| seed | number | Seed for random number generation | 754970612881900 |\n| steps | number | Number of sampling steps | 4 |\n| cfg_scale | number | Classifier-free guidance scale | 1 |\n| sampler_name | enum (`euler`, `euler_cfg_pp`, `euler_ancestral`, `euler_ancestral_cfg_pp`, `heun`, `heunpp2`, `dpm_2`, `dpm_2_ancestral`, `lms`, `dpm_fast`, `dpm_adaptive`, `dpmpp_2s_ancestral`, `dpmpp_sde`, `dpmpp_sde_gpu`, `dpmpp_2m`, `dpmpp_2m_sde`, `dpmpp_2m_sde_gpu`, `dpmpp_3m_sde`, `dpmpp_3m_sde_gpu`, `ddpm`, `lcm`, `ipndm`, `ipndm_v`, `deis`, `ddim`, `uni_pc`, `uni_pc_bh2`) | Name of the sampler to use | \"euler\" |\n| scheduler | enum (`normal`, `karras`, `exponential`, `sgm_uniform`, `simple`, `ddim_uniform`, `beta`) | Type of scheduler to use | \"simple\" |\n| denoise | number | Denoising strength | 0.8 |\n| checkpoint | enum (`flux1-schnell-fp8.safetensors`) |  | \"flux1-schnell-fp8.safetensors\" |\n| image | string | Input image for img2img | - |\n| interpolation | enum (`nearest`) | Interpolation method for image resizing | \"nearest\" |\n| resize_method | enum (`fill / crop`) | Method for resizing the image | \"fill / crop\" |\n| resize_condition | enum (`always`) | Condition for when to resize the image | \"always\" |\n| multiple_of | number | Ensure image dimensions are multiples of this value | 8 |\n",
+        "summary": "Image to Image",
+        "description": "Generate an image from another image and a text prompt",
         "requestBody": {
           "content": {
             "application/json": {
@@ -306,7 +470,7 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "default": "43272ec9-eaf1-4c0f-8400-4377616cd738"
+                    "default": "e962da6d-2760-4687-80b7-23ce811d79db"
                   },
                   "input": {
                     "type": "object",
@@ -331,7 +495,7 @@
                       },
                       "seed": {
                         "type": "integer",
-                        "default": 4672557444369,
+                        "default": 276274727623346,
                         "description": "Seed for random number generation"
                       },
                       "steps": {
@@ -405,7 +569,9 @@
                       },
                       "checkpoint": {
                         "type": "string",
-                        "enum": ["flux1-schnell-fp8.safetensors"],
+                        "enum": [
+                          "flux1-schnell-fp8.safetensors"
+                        ],
                         "default": "flux1-schnell-fp8.safetensors"
                       },
                       "image": {
@@ -414,19 +580,25 @@
                       },
                       "interpolation": {
                         "type": "string",
-                        "enum": ["nearest"],
+                        "enum": [
+                          "nearest"
+                        ],
                         "default": "nearest",
                         "description": "Interpolation method for image resizing"
                       },
                       "resize_method": {
                         "type": "string",
-                        "enum": ["fill / crop"],
+                        "enum": [
+                          "fill / crop"
+                        ],
                         "default": "fill / crop",
                         "description": "Method for resizing the image"
                       },
                       "resize_condition": {
                         "type": "string",
-                        "enum": ["always"],
+                        "enum": [
+                          "always"
+                        ],
                         "default": "always",
                         "description": "Condition for when to resize the image"
                       },
@@ -436,12 +608,19 @@
                         "description": "Ensure image dimensions are multiples of this value"
                       }
                     },
-                    "required": ["prompt", "image"],
+                    "required": [
+                      "prompt",
+                      "image"
+                    ],
                     "additionalProperties": false
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["input"],
+                "required": [
+                  "input"
+                ],
                 "additionalProperties": false
               }
             }
@@ -456,29 +635,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -491,29 +693,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -524,7 +749,8 @@
     },
     "/workflow/flux/txt2img": {
       "post": {
-        "description": "| Field | Type | Description | Default |\n|-|-|-|-|\n| prompt | string | The positive prompt for image generation | - |\n| width | number | Width of the generated image | 1024 |\n| height | number | Height of the generated image | 1024 |\n| seed | number | Seed for random number generation | 896117127594843 |\n| steps | number | Number of sampling steps | 4 |\n| cfg_scale | number | Classifier-free guidance scale | 1 |\n| sampler_name | enum (`euler`, `euler_cfg_pp`, `euler_ancestral`, `euler_ancestral_cfg_pp`, `heun`, `heunpp2`, `dpm_2`, `dpm_2_ancestral`, `lms`, `dpm_fast`, `dpm_adaptive`, `dpmpp_2s_ancestral`, `dpmpp_sde`, `dpmpp_sde_gpu`, `dpmpp_2m`, `dpmpp_2m_sde`, `dpmpp_2m_sde_gpu`, `dpmpp_3m_sde`, `dpmpp_3m_sde_gpu`, `ddpm`, `lcm`, `ipndm`, `ipndm_v`, `deis`, `ddim`, `uni_pc`, `uni_pc_bh2`) | Name of the sampler to use | \"euler\" |\n| scheduler | enum (`normal`, `karras`, `exponential`, `sgm_uniform`, `simple`, `ddim_uniform`, `beta`) | Type of scheduler to use | \"simple\" |\n| denoise | number | Denoising strength | 1 |\n| checkpoint | enum (`flux1-schnell-fp8.safetensors`) |  | \"flux1-schnell-fp8.safetensors\" |\n",
+        "summary": "Text to Image",
+        "description": "Generate an image from a text prompt",
         "requestBody": {
           "content": {
             "application/json": {
@@ -533,7 +759,7 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "default": "8865904a-af87-4fa9-bb21-9b397b0c8e6a"
+                    "default": "7840d0c9-c8d7-496f-9f75-54755b965e32"
                   },
                   "input": {
                     "type": "object",
@@ -558,7 +784,7 @@
                       },
                       "seed": {
                         "type": "integer",
-                        "default": 490369469465705,
+                        "default": 1048774136044,
                         "description": "Seed for random number generation"
                       },
                       "steps": {
@@ -632,16 +858,24 @@
                       },
                       "checkpoint": {
                         "type": "string",
-                        "enum": ["flux1-schnell-fp8.safetensors"],
+                        "enum": [
+                          "flux1-schnell-fp8.safetensors"
+                        ],
                         "default": "flux1-schnell-fp8.safetensors"
                       }
                     },
-                    "required": ["prompt"],
+                    "required": [
+                      "prompt"
+                    ],
                     "additionalProperties": false
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["input"],
+                "required": [
+                  "input"
+                ],
                 "additionalProperties": false
               }
             }
@@ -656,29 +890,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -691,29 +948,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }

--- a/src/flux1-schnell-fp8-comfyui/workflows/flux/img2img.ts
+++ b/src/flux1-schnell-fp8-comfyui/workflows/flux/img2img.ts
@@ -12,6 +12,8 @@ type ComfyNode = z.infer<typeof ComfyNodeSchema>;
 interface Workflow {
   RequestSchema: z.ZodObject<any, any>;
   generateWorkflow: (input: any) => Record<string, ComfyNode>;
+  description?: string;
+  summary?: string;
 }
 
 let checkpoint: any = config.models.checkpoints.enum.optional();
@@ -210,6 +212,8 @@ function generateWorkflow(input: InputType): Record<string, ComfyNode> {
 const workflow: Workflow = {
   RequestSchema,
   generateWorkflow,
+  summary: "Image to Image",
+  description: "Generate an image from another image and a text prompt",
 };
 
 export default workflow;

--- a/src/flux1-schnell-fp8-comfyui/workflows/flux/txt2img.ts
+++ b/src/flux1-schnell-fp8-comfyui/workflows/flux/txt2img.ts
@@ -12,6 +12,8 @@ type ComfyNode = z.infer<typeof ComfyNodeSchema>;
 interface Workflow {
   RequestSchema: z.ZodObject<any, any>;
   generateWorkflow: (input: any) => Record<string, ComfyNode>;
+  description?: string;
+  summary?: string;
 }
 
 let checkpoint: any = config.models.checkpoints.enum.optional();
@@ -164,6 +166,8 @@ function generateWorkflow(input: InputType): Record<string, ComfyNode> {
 const workflow: Workflow = {
   RequestSchema,
   generateWorkflow,
+  summary: "Text to Image",
+  description: "Generate an image from a text prompt",
 };
 
 export default workflow;

--- a/src/get-container-group.js
+++ b/src/get-container-group.js
@@ -8,10 +8,20 @@ const headers = {
   'Salad-Api-Key': SALAD_API_KEY
 };
 
+const usage = `
+Usage: node get-container-group.js <container-group-address> <output-file>
+
+Example:
+node get-container-group.js \
+organizations/salad-benchmarking/projects/recipe-staging/containers/comfyui-dreamshaper8 \
+dreamshaper8-comfyui/container-group.json
+`
+
 async function main() {
   const cgAddress = process.argv[2];
   const output = process.argv[3];
-  assert(cgAddress, 'Container Group address is required')
+  assert(cgAddress, usage)
+  assert(output, usage)
   const cgUrl=`https://api.salad.com/api/public/${cgAddress}`
   console.log(`Fetching container group from ${cgUrl}`)
 

--- a/src/get-container-group.js
+++ b/src/get-container-group.js
@@ -1,0 +1,58 @@
+const assert = require('assert')
+const fs = require('fs')
+
+const { SALAD_API_KEY } = process.env
+assert(SALAD_API_KEY, 'SALAD_API_KEY is required')
+
+const headers = {
+  'Salad-Api-Key': SALAD_API_KEY
+};
+
+async function main() {
+  const cgAddress = process.argv[2];
+  const output = process.argv[3];
+  assert(cgAddress, 'Container Group address is required')
+  const cgUrl=`https://api.salad.com/api/public/${cgAddress}`
+  console.log(`Fetching container group from ${cgUrl}`)
+
+  const res = await fetch(cgUrl, { headers })
+  if (!res.ok) {
+    console.log(await res.text())
+    throw new Error(`Failed to fetch container group: ${res.status} ${res.statusText}`)
+  }
+  const containerGroup = await res.json()
+
+  const {
+    name,
+    display_name,
+    container,
+    restart_policy,
+    networking,
+    readiness_probe,
+    startup_probe,
+    liveness_probe,
+  } = containerGroup;
+
+  delete container.size;
+  delete container.hash;
+  container.priority = "high";
+
+  delete networking.dns;
+ 
+  const newDef = {
+    name,
+    display_name,
+    container,
+    autostart_policy: true,
+    restart_policy,
+    replicas: 3,
+    networking,
+    readiness_probe,
+    startup_probe,
+    liveness_probe,
+  }
+
+  fs.writeFileSync(output, JSON.stringify(newDef, null, 2));
+}
+
+main()

--- a/src/sdxl-with-refiner-comfyui/Dockerfile
+++ b/src/sdxl-with-refiner-comfyui/Dockerfile
@@ -1,6 +1,6 @@
 # We're going to use this verified comfyui image as a base
 ARG comfy_version=0.2.0
-ARG api_version=1.4.0
+ARG api_version=1.4.1
 FROM saladtechnologies/comfyui:comfy${comfy_version}-api${api_version}-base
 
 ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints

--- a/src/sdxl-with-refiner-comfyui/container-group.json
+++ b/src/sdxl-with-refiner-comfyui/container-group.json
@@ -2,25 +2,34 @@
   "name": "comfyui-sdxl-with-refiner",
   "display_name": "comfyui-sdxl-with-refiner",
   "container": {
-    "image": "saladtechnologies/comfyui:comfy0.2.0-api1.4.0-sdxl-with-refiner",
+    "image": "saladtechnologies/comfyui:comfy0.2.0-api1.4.1-sdxl-with-refiner",
     "resources": {
       "cpu": 4,
       "memory": 30720,
-      "gpu_classes": ["ed563892-aacd-40f5-80b7-90c9be6c759b"],
+      "gpu_classes": [
+        "ed563892-aacd-40f5-80b7-90c9be6c759b"
+      ],
       "storage_amount": 1073741824
     },
-    "command": []
+    "command": [],
+    "priority": "high"
   },
-  "autostart_policy": false,
+  "autostart_policy": true,
   "restart_policy": "always",
   "replicas": 3,
   "networking": {
     "protocol": "http",
     "port": 3000,
-    "auth": false
+    "auth": false,
+    "load_balancer": "round_robin"
   },
   "readiness_probe": {
-    "http": { "path": "/ready", "port": 3000, "scheme": "http", "headers": [] },
+    "http": {
+      "path": "/ready",
+      "port": 3000,
+      "scheme": "http",
+      "headers": []
+    },
     "initial_delay_seconds": 0,
     "period_seconds": 2,
     "timeout_seconds": 2,

--- a/src/sdxl-with-refiner-comfyui/get-openapi-spec
+++ b/src/sdxl-with-refiner-comfyui/get-openapi-spec
@@ -1,0 +1,60 @@
+#! /usr/bin/bash
+set -e
+
+image="saladtechnologies/comfyui"
+usage="Usage: ./get-openapi-spec --comfy <comfy-version> --api <api-version> [--image <image> default: $image]"
+
+model_name="sdxl-with-refiner"
+while [ "$1" != "" ]; do
+  case $1 in
+  --comfy)
+    shift
+    comfy_version=$1
+    ;;
+  --api)
+    shift
+    api_version=$1
+    ;;
+  --image)
+    shift
+    image=$1
+    ;;
+  *)
+    echo $usage
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+if [ -z "$comfy_version" ] || [ -z "$api_version" ]; then
+  echo $usage
+  exit 1
+fi
+
+tag="comfy$comfy_version-api$api_version-$model_name"
+
+# Start the server
+echo "Starting server..."
+docker run --rm --gpus all \
+-p 3000:3000 \
+--name comfyui-$model_name \
+-e MARKDOWN_SCHEMA_DESCRIPTIONS="false" \
+$image:$tag &
+
+function healthcheck {
+  curl -s http://localhost:3000/health > /dev/null
+}
+
+until healthcheck; do
+  echo "Waiting for server to start..."
+  sleep 1
+done
+
+# Download the spec to a file called openapi.json
+echo "Downloading OpenAPI spec..."
+curl -s http://localhost:3000/docs/json | jq . > openapi.json
+
+# Stop the server
+echo "Stopping server..."
+docker stop comfyui-$model_name

--- a/src/sdxl-with-refiner-comfyui/openapi.json
+++ b/src/sdxl-with-refiner-comfyui/openapi.json
@@ -1,10 +1,17 @@
 {
   "openapi": "3.0.0",
-  "info": { "title": "Comfy Wrapper API", "version": "1.4.0" },
-  "components": { "schemas": {} },
+  "info": {
+    "title": "Comfy Wrapper API",
+    "version": "1.4.1"
+  },
+  "components": {
+    "schemas": {}
+  },
   "paths": {
     "/health": {
       "get": {
+        "summary": "Health Probe",
+        "description": "Check if the server is healthy",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -13,10 +20,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["healthy"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "healthy"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -29,10 +49,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["not healthy"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "not healthy"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -43,6 +76,8 @@
     },
     "/ready": {
       "get": {
+        "summary": "Readiness Probe",
+        "description": "Check if the server is ready to serve traffic",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -51,10 +86,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["ready"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ready"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -67,10 +115,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "version": { "type": "string", "enum": ["1.4.0"] },
-                    "status": { "type": "string", "enum": ["not ready"] }
+                    "version": {
+                      "type": "string",
+                      "enum": [
+                        "1.4.1"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "not ready"
+                      ]
+                    }
                   },
-                  "required": ["version", "status"],
+                  "required": [
+                    "version",
+                    "status"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -81,6 +142,8 @@
     },
     "/models": {
       "get": {
+        "summary": "List Models",
+        "description": "List all available models. This is from the contents of the models directory.",
         "responses": {
           "200": {
             "description": "Default Response",
@@ -91,59 +154,105 @@
                   "properties": {
                     "checkpoints": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "clip": { "type": "array", "items": { "type": "string" } },
+                    "clip": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "clip_vision": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "configs": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "controlnet": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "diffusers": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "diffusion_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "embeddings": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "gligen": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "hypernetworks": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "loras": { "type": "array", "items": { "type": "string" } },
+                    "loras": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "photomaker": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "style_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "unet": { "type": "array", "items": { "type": "string" } },
+                    "unet": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "upscale_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
-                    "vae": { "type": "array", "items": { "type": "string" } },
+                    "vae": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "vae_approx": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -175,6 +284,8 @@
     },
     "/prompt": {
       "post": {
+        "summary": "Submit Prompt",
+        "description": "Submit an API-formatted ComfyUI prompt.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -187,20 +298,28 @@
                       "type": "object",
                       "properties": {
                         "inputs": {},
-                        "class_type": { "type": "string" },
+                        "class_type": {
+                          "type": "string"
+                        },
                         "_meta": {}
                       },
-                      "required": ["class_type"],
+                      "required": [
+                        "class_type"
+                      ],
                       "additionalProperties": false
                     }
                   },
                   "id": {
                     "type": "string",
-                    "default": "9effb884-c24d-43c7-8027-a003d0aa7988"
+                    "default": "435d3691-4868-4465-a8df-ce13651339ad"
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["prompt"],
+                "required": [
+                  "prompt"
+                ],
                 "additionalProperties": false
               }
             }
@@ -215,28 +334,47 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
+                    "id": {
+                      "type": "string"
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "prompt"],
+                  "required": [
+                    "id",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -249,28 +387,47 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
+                    "id": {
+                      "type": "string"
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "prompt"],
+                  "required": [
+                    "id",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -283,10 +440,16 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": { "type": "string" },
-                    "location": { "type": "string" }
+                    "error": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -297,7 +460,8 @@
     },
     "/workflow/sdxl/img2img": {
       "post": {
-        "description": "| Field | Type | Description | Default |\n|-|-|-|-|\n| prompt | string | The positive prompt for image generation | - |\n| negative_prompt | string | The negative prompt for image generation | - |\n| width | number | Width of the generated image | 4096 |\n| height | number | Height of the generated image | 4096 |\n| seed | number | Seed for random number generation | 511175242584909 |\n| steps | number | Number of sampling steps | 20 |\n| cfg_scale | number | Classifier-free guidance scale | 5.5 |\n| sampler_name | enum (`euler`, `euler_cfg_pp`, `euler_ancestral`, `euler_ancestral_cfg_pp`, `heun`, `heunpp2`, `dpm_2`, `dpm_2_ancestral`, `lms`, `dpm_fast`, `dpm_adaptive`, `dpmpp_2s_ancestral`, `dpmpp_sde`, `dpmpp_sde_gpu`, `dpmpp_2m`, `dpmpp_2m_sde`, `dpmpp_2m_sde_gpu`, `dpmpp_3m_sde`, `dpmpp_3m_sde_gpu`, `ddpm`, `lcm`, `ipndm`, `ipndm_v`, `deis`, `ddim`, `uni_pc`, `uni_pc_bh2`) | Name of the sampler to use | \"dpmpp_2m_sde_gpu\" |\n| scheduler | enum (`normal`, `karras`, `exponential`, `sgm_uniform`, `simple`, `ddim_uniform`, `beta`) | Type of scheduler to use | \"exponential\" |\n| denoise | number | Denoising strength | 0.75 |\n| checkpoint | enum (`sd_xl_base_1.0.safetensors`, `sd_xl_refiner_1.0.safetensors`) |  | \"sd_xl_base_1.0.safetensors\" |\n| image | string | Input image for img2img | - |\n| upscale_method | enum (`nearest-exact`) | Method used for upscaling if input image is smaller than target size | \"nearest-exact\" |\n| target_width | number | Target width for upscaling | 1024 |\n| target_height | number | Target height for upscaling | 1024 |\n",
+        "summary": "Image to Image",
+        "description": "Generate an image from another image and a text prompt",
         "requestBody": {
           "content": {
             "application/json": {
@@ -306,7 +470,7 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "default": "cc1dd8da-9874-4354-8689-faf2c6924b35"
+                    "default": "a8d36132-2a67-4c66-b0c3-af0e60f9a617"
                   },
                   "input": {
                     "type": "object",
@@ -335,7 +499,7 @@
                       },
                       "seed": {
                         "type": "integer",
-                        "default": 597440185341559,
+                        "default": 344634302797716,
                         "description": "Seed for random number generation"
                       },
                       "steps": {
@@ -421,7 +585,9 @@
                       },
                       "upscale_method": {
                         "type": "string",
-                        "enum": ["nearest-exact"],
+                        "enum": [
+                          "nearest-exact"
+                        ],
                         "default": "nearest-exact",
                         "description": "Method used for upscaling if input image is smaller than target size"
                       },
@@ -440,12 +606,19 @@
                         "description": "Target height for upscaling"
                       }
                     },
-                    "required": ["prompt", "image"],
+                    "required": [
+                      "prompt",
+                      "image"
+                    ],
                     "additionalProperties": false
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["input"],
+                "required": [
+                  "input"
+                ],
                 "additionalProperties": false
               }
             }
@@ -460,29 +633,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -495,29 +691,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -528,7 +747,8 @@
     },
     "/workflow/sdxl/txt2img-with-refiner": {
       "post": {
-        "description": "| Field | Type | Description | Default |\n|-|-|-|-|\n| prompt | string | The positive prompt for image generation | - |\n| negative_prompt | string | The negative prompt for image generation | \"text, watermark\" |\n| width | number | Width of the generated image | 1024 |\n| height | number | Height of the generated image | 1024 |\n| seed | number | Seed for random number generation | 588181349326232 |\n| steps | number | Number of sampling steps | 25 |\n| cfg_scale | number | Classifier-free guidance scale | 8 |\n| sampler_name | enum (`euler`, `euler_cfg_pp`, `euler_ancestral`, `euler_ancestral_cfg_pp`, `heun`, `heunpp2`, `dpm_2`, `dpm_2_ancestral`, `lms`, `dpm_fast`, `dpm_adaptive`, `dpmpp_2s_ancestral`, `dpmpp_sde`, `dpmpp_sde_gpu`, `dpmpp_2m`, `dpmpp_2m_sde`, `dpmpp_2m_sde_gpu`, `dpmpp_3m_sde`, `dpmpp_3m_sde_gpu`, `ddpm`, `lcm`, `ipndm`, `ipndm_v`, `deis`, `ddim`, `uni_pc`, `uni_pc_bh2`) | Name of the sampler to use | \"euler\" |\n| scheduler | enum (`normal`, `karras`, `exponential`, `sgm_uniform`, `simple`, `ddim_uniform`, `beta`) | Type of scheduler to use | \"normal\" |\n| base_start_step | number | Start step for base model sampling | 0 |\n| base_end_step | number | End step for base model sampling | 20 |\n| refiner_start_step | number | Start step for refiner model sampling | 20 |\n| checkpoint | enum (`sd_xl_base_1.0.safetensors`, `sd_xl_refiner_1.0.safetensors`) |  | \"sd_xl_base_1.0.safetensors\" |\n| refiner_checkpoint | string | Checkpoint for the refiner model | \"sd_xl_refiner_1.0.safetensors\" |\n",
+        "summary": "Text to Image (+Refiner)",
+        "description": "Generate an image from a text prompt, and refine it with the refiner model",
         "requestBody": {
           "content": {
             "application/json": {
@@ -537,7 +757,7 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "default": "07152ec8-4692-4dc2-b12f-997564c76232"
+                    "default": "9327ecde-9d23-4858-ab5a-bdadeb9cc10f"
                   },
                   "input": {
                     "type": "object",
@@ -567,7 +787,7 @@
                       },
                       "seed": {
                         "type": "integer",
-                        "default": 699836521794580,
+                        "default": 297306351377682,
                         "description": "Seed for random number generation"
                       },
                       "steps": {
@@ -667,12 +887,18 @@
                         "description": "Checkpoint for the refiner model"
                       }
                     },
-                    "required": ["prompt"],
+                    "required": [
+                      "prompt"
+                    ],
                     "additionalProperties": false
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["input"],
+                "required": [
+                  "input"
+                ],
                 "additionalProperties": false
               }
             }
@@ -687,29 +913,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -722,29 +971,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -755,7 +1027,8 @@
     },
     "/workflow/sdxl/txt2img": {
       "post": {
-        "description": "| Field | Type | Description | Default |\n|-|-|-|-|\n| prompt | string | The positive prompt for image generation | - |\n| negative_prompt | string | The negative prompt for image generation | \"text, watermark\" |\n| width | number | Width of the generated image | 1024 |\n| height | number | Height of the generated image | 1024 |\n| seed | number | Seed for random number generation | 10098672545 |\n| steps | number | Number of sampling steps | 20 |\n| cfg_scale | number | Classifier-free guidance scale | 8 |\n| sampler_name | enum (`euler`, `euler_cfg_pp`, `euler_ancestral`, `euler_ancestral_cfg_pp`, `heun`, `heunpp2`, `dpm_2`, `dpm_2_ancestral`, `lms`, `dpm_fast`, `dpm_adaptive`, `dpmpp_2s_ancestral`, `dpmpp_sde`, `dpmpp_sde_gpu`, `dpmpp_2m`, `dpmpp_2m_sde`, `dpmpp_2m_sde_gpu`, `dpmpp_3m_sde`, `dpmpp_3m_sde_gpu`, `ddpm`, `lcm`, `ipndm`, `ipndm_v`, `deis`, `ddim`, `uni_pc`, `uni_pc_bh2`) | Name of the sampler to use | \"euler\" |\n| scheduler | enum (`normal`, `karras`, `exponential`, `sgm_uniform`, `simple`, `ddim_uniform`, `beta`) | Type of scheduler to use | \"normal\" |\n| denoise | number | Denoising strength | 1 |\n| checkpoint | enum (`sd_xl_base_1.0.safetensors`, `sd_xl_refiner_1.0.safetensors`) |  | \"sd_xl_base_1.0.safetensors\" |\n",
+        "summary": "Text to Image",
+        "description": "Generate an image from a text prompt",
         "requestBody": {
           "content": {
             "application/json": {
@@ -764,7 +1037,7 @@
                 "properties": {
                   "id": {
                     "type": "string",
-                    "default": "f9e66eab-45fe-46da-b694-2c4ee9b7facf"
+                    "default": "c83cd1f3-5776-440d-82da-965b21275e57"
                   },
                   "input": {
                     "type": "object",
@@ -794,7 +1067,7 @@
                       },
                       "seed": {
                         "type": "integer",
-                        "default": 34616222748,
+                        "default": 20119024750,
                         "description": "Seed for random number generation"
                       },
                       "steps": {
@@ -875,12 +1148,18 @@
                         "default": "sd_xl_base_1.0.safetensors"
                       }
                     },
-                    "required": ["prompt"],
+                    "required": [
+                      "prompt"
+                    ],
                     "additionalProperties": false
                   },
-                  "webhook": { "type": "string" }
+                  "webhook": {
+                    "type": "string"
+                  }
                 },
-                "required": ["input"],
+                "required": [
+                  "input"
+                ],
                 "additionalProperties": false
               }
             }
@@ -895,29 +1174,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -930,29 +1232,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "input": { "type": "object", "additionalProperties": {} },
+                    "id": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
                     "prompt": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "inputs": {},
-                          "class_type": { "type": "string" },
+                          "class_type": {
+                            "type": "string"
+                          },
                           "_meta": {}
                         },
-                        "required": ["class_type"],
+                        "required": [
+                          "class_type"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "images": {
                       "type": "array",
-                      "items": { "type": "string", "contentEncoding": "base64" }
+                      "items": {
+                        "type": "string",
+                        "contentEncoding": "base64"
+                      }
                     },
-                    "webhook": { "type": "string" },
-                    "status": { "type": "string", "enum": ["ok"] }
+                    "webhook": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
                   },
-                  "required": ["id", "input", "prompt"],
+                  "required": [
+                    "id",
+                    "input",
+                    "prompt"
+                  ],
                   "additionalProperties": false
                 }
               }

--- a/src/sdxl-with-refiner-comfyui/workflows/sdxl/img2img.ts
+++ b/src/sdxl-with-refiner-comfyui/workflows/sdxl/img2img.ts
@@ -12,6 +12,8 @@ type ComfyNode = z.infer<typeof ComfyNodeSchema>;
 interface Workflow {
   RequestSchema: z.ZodObject<any, any>;
   generateWorkflow: (input: any) => Record<string, ComfyNode>;
+  description?: string;
+  summary?: string;
 }
 
 let checkpoint: any = config.models.checkpoints.enum.optional();
@@ -228,6 +230,8 @@ function generateWorkflow(input: InputType): Record<string, ComfyNode> {
 const workflow: Workflow = {
   RequestSchema,
   generateWorkflow,
+  summary: "Image to Image",
+  description: "Generate an image from another image and a text prompt",
 };
 
 export default workflow;

--- a/src/sdxl-with-refiner-comfyui/workflows/sdxl/txt2img-with-refiner.ts
+++ b/src/sdxl-with-refiner-comfyui/workflows/sdxl/txt2img-with-refiner.ts
@@ -12,6 +12,8 @@ type ComfyNode = z.infer<typeof ComfyNodeSchema>;
 interface Workflow {
   RequestSchema: z.ZodObject<any, any>;
   generateWorkflow: (input: any) => Record<string, ComfyNode>;
+  description?: string;
+  summary?: string;
 }
 
 let checkpoint: any = config.models.checkpoints.enum.optional();
@@ -244,6 +246,9 @@ function generateWorkflow(input: InputType): Record<string, ComfyNode> {
 const workflow: Workflow = {
   RequestSchema,
   generateWorkflow,
+  summary: "Text to Image (+Refiner)",
+  description:
+    "Generate an image from a text prompt, and refine it with the refiner model",
 };
 
 export default workflow;

--- a/src/sdxl-with-refiner-comfyui/workflows/sdxl/txt2img.ts
+++ b/src/sdxl-with-refiner-comfyui/workflows/sdxl/txt2img.ts
@@ -12,6 +12,8 @@ type ComfyNode = z.infer<typeof ComfyNodeSchema>;
 interface Workflow {
   RequestSchema: z.ZodObject<any, any>;
   generateWorkflow: (input: any) => Record<string, ComfyNode>;
+  description?: string;
+  summary?: string;
 }
 
 let checkpoint: any = config.models.checkpoints.enum.optional();
@@ -169,6 +171,8 @@ function generateWorkflow(input: InputType): Record<string, ComfyNode> {
 const workflow: Workflow = {
   RequestSchema,
   generateWorkflow,
+  summary: "Text to Image",
+  description: "Generate an image from a text prompt",
 };
 
 export default workflow;


### PR DESCRIPTION
This updates the image gen recipes to use the new comfy api 1.4.1 which has better openapi generation.

It also adds 2 new pieces of automation:
- In `src/` we have a script, `get-container-group.js` that is used to retrieve a container group definition from the api, and strip out everything except what is needed to create a new container group. This should reduce manual errors.
- In each recipe directory updated, there's a new script `./get-openapi-spec` that starts the server, and downloads the open api spec from the running server.