### PR TITLE
Comfy 0.2.6

### DIFF
--- a/src/comfyui-base/Dockerfile
+++ b/src/comfyui-base/Dockerfile
@@ -1,4 +1,4 @@
-ARG comfy_version=0.2.2
+ARG comfy_version=0.2.6
 FROM ghcr.io/ai-dock/comfyui:v2-cuda-12.1.1-base-22.04-v${comfy_version}
 
 # Disable the authentication and cloudflare tunnels provided by the base image
@@ -29,5 +29,10 @@ ENV INPUT_DIR=/opt/ComfyUI/input
 # Startup can take a little longer with larger models.
 # This configures the worker binary's built-in health check.
 ENV STARTUP_CHECK_MAX_TRIES=30
+
+RUN pip install --upgrade pip
+RUN pip install comfy-cli
+RUN echo "N" | comfy tracking disable
+RUN comfy set-default /opt/ComfyUI/
 
 CMD ["./comfyui-api"]

--- a/src/comfyui-base/Dockerfile
+++ b/src/comfyui-base/Dockerfile
@@ -30,8 +30,11 @@ ENV INPUT_DIR=/opt/ComfyUI/input
 # This configures the worker binary's built-in health check.
 ENV STARTUP_CHECK_MAX_TRIES=30
 
+# Install comfy-cli, which makes it easy to install custom nodes and other comfy specific functionality.
 RUN pip install --upgrade pip
 RUN pip install comfy-cli
+
+# Disable tracking and set the default directory to /opt/ComfyUI/
 RUN echo "N" | comfy tracking disable
 RUN comfy set-default /opt/ComfyUI/
 

--- a/src/comfyui-base/readme.md
+++ b/src/comfyui-base/readme.md
@@ -1,3 +1,5 @@
 # ComfyUI Base Image
 
 This repository contains the base image for ComfyUI recipes. It builds on the ai-dock comfy base image and adds the [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api) server.
+
+Starting with comfy version 0.2.6, it also includes the [ComfyUI CLI](https://github.com/Comfy-Org/comfy-cli) for easy node management.

--- a/src/comfyui-base/readme.md
+++ b/src/comfyui-base/readme.md
@@ -1,5 +1,5 @@
 # ComfyUI Base Image
 
-This repository contains the base image for ComfyUI recipes. It builds on the ai-dock comfy base image and adds the [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api) server.
+This directory contains the base image for ComfyUI recipes. It builds on the ai-dock comfy base image and adds the [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api) server.
 
 Starting with comfy version 0.2.6, it also includes the [ComfyUI CLI](https://github.com/Comfy-Org/comfy-cli) for easy node management.

--- a/src/dreamshaper8-comfyui/Dockerfile
+++ b/src/dreamshaper8-comfyui/Dockerfile
@@ -1,5 +1,5 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.2.2
+ARG comfy_version=0.2.6
 ARG api_version=1.4.2
 FROM saladtechnologies/comfyui:comfy${comfy_version}-api${api_version}-base
 

--- a/src/dreamshaper8-comfyui/container-group.json
+++ b/src/dreamshaper8-comfyui/container-group.json
@@ -2,7 +2,7 @@
   "name": "dreamshaper8-comfyui",
   "display_name": "dreamshaper8-comfyui",
   "container": {
-    "image": "saladtechnologies/comfyui:comfy0.2.2-api1.4.2-dreamshaper8",
+    "image": "saladtechnologies/comfyui:comfy0.2.6-api1.4.2-dreamshaper8",
     "resources": {
       "cpu": 4,
       "memory": 12288,

--- a/src/flux1-schnell-fp8-comfyui/Dockerfile
+++ b/src/flux1-schnell-fp8-comfyui/Dockerfile
@@ -1,5 +1,5 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.2.2
+ARG comfy_version=0.2.6
 ARG api_version=1.4.2
 FROM saladtechnologies/comfyui:comfy${comfy_version}-api${api_version}-base
 

--- a/src/flux1-schnell-fp8-comfyui/container-group.json
+++ b/src/flux1-schnell-fp8-comfyui/container-group.json
@@ -2,7 +2,7 @@
   "name": "flux1-schnell-fp8-comfyui",
   "display_name": "flux1-schnell-fp8-comfyui",
   "container": {
-    "image": "saladtechnologies/comfyui:comfy0.2.2-api1.4.2-flux1-schnell-fp8",
+    "image": "saladtechnologies/comfyui:comfy0.2.6-api1.4.2-flux1-schnell-fp8",
     "resources": {
       "cpu": 4,
       "memory": 30720,

--- a/src/sdxl-with-refiner-comfyui/Dockerfile
+++ b/src/sdxl-with-refiner-comfyui/Dockerfile
@@ -1,5 +1,5 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.2.2
+ARG comfy_version=0.2.6
 ARG api_version=1.4.2
 FROM saladtechnologies/comfyui:comfy${comfy_version}-api${api_version}-base
 

--- a/src/sdxl-with-refiner-comfyui/container-group.json
+++ b/src/sdxl-with-refiner-comfyui/container-group.json
@@ -2,7 +2,7 @@
   "name": "sdxl-with-refiner-comfyui",
   "display_name": "sdxl-with-refiner-comfyui",
   "container": {
-    "image": "saladtechnologies/comfyui:comfy0.2.2-api1.4.2-sdxl-with-refiner",
+    "image": "saladtechnologies/comfyui:comfy0.2.6-api1.4.2-sdxl-with-refiner",
     "resources": {
       "cpu": 4,
       "memory": 30720,


### PR DESCRIPTION
- updates all image gen recipes to use comfyui 0.2.6, which has support for sd3.5.
- add comfyui cli to the base image and all recipes, to make it easier to install custom nodes.