### PR TITLE
Update image gen recipes

### DIFF
--- a/recipes/ai-toolkit/Dockerfile
+++ b/recipes/ai-toolkit/Dockerfile
@@ -1,6 +1,6 @@
 FROM saladtechnologies/ai-toolkit:cuda12.8-flux1-dev
 
-ADD https://github.com/SaladTechnologies/kelpie/releases/download/0.6.0/kelpie /kelpie
+ADD https://github.com/SaladTechnologies/kelpie/releases/download/0.6.1/kelpie /kelpie
 RUN chmod +x /kelpie
 
 CMD ["/kelpie"]

--- a/recipes/ai-toolkit/form.json
+++ b/recipes/ai-toolkit/form.json
@@ -6,8 +6,7 @@
     "container_group_name",
     "aws_access_key_id",
     "aws_secret_access_key",
-    "aws_region",
-    "salad_project"
+    "aws_region"
   ],
   "properties": {
     "container_group_name": {
@@ -46,13 +45,6 @@
       "type": "string",
       "maxLength": 256,
       "minLength": 0
-    },
-    "salad_project": {
-      "title": "Salad Project",
-      "description": "Required* The Salad project to use for this worker.",
-      "type": "string",
-      "maxLength": 64,
-      "minLength": 1
     }
   }
 }

--- a/recipes/ai-toolkit/recipe.json
+++ b/recipes/ai-toolkit/recipe.json
@@ -22,7 +22,7 @@
     "title": "AI Toolkit - Flux 1 Dev",
     "description": "# AI Toolkit: Flux 1 Dev\n\nThis recipe provides an example implementation for using [AI Toolkit](https://github.com/ostris/ai-toolkit) to train LoRA models for the [Flux1-Dev](https://huggingface.co/black-forest-labs/FLUX.1-dev) image generation model. Note that this model is [not licensed for commercial use](https://github.com/black-forest-labs/flux/blob/main/model_licenses/LICENSE-FLUX1-dev), so please ensure you have the appropriate rights to use it for your intended purpose.\n\nThis recipe uses [Kelpie](https://github.com/SaladTechnologies/kelpie) and the [Kelpie API](https://kelpie.saladexamples.com/docs) to manage the training jobs. Kelpie is a job queueing system that allows you to run long-running jobs on Salad's infrastructure, as well as manage data transfer between servers and s3-compatible storage.\n\nKelpie has an optional autoscaling feature that automates adjusting replica count based on the number of queued jobs, including scale-to-zero when the queue is empty.",
     "type": "object",
-    "required": ["container_group_name", "aws_access_key_id", "aws_secret_access_key", "aws_region", "salad_project"],
+    "required": ["container_group_name", "aws_access_key_id", "aws_secret_access_key", "aws_region"],
     "properties": {
       "container_group_name": {
         "title": "Container Group Name",
@@ -60,13 +60,6 @@
         "type": "string",
         "maxLength": 256,
         "minLength": 0
-      },
-      "salad_project": {
-        "title": "Salad Project",
-        "description": "Required* The Salad project to use for this worker.",
-        "type": "string",
-        "maxLength": 64,
-        "minLength": 1
       }
     }
   },

--- a/recipes/comfyui/Dockerfile.dreamshaper8
+++ b/recipes/comfyui/Dockerfile.dreamshaper8
@@ -1,12 +1,11 @@
-# We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.61
+ARG comfy_version=0.3.62
 ARG torch_version=2.8.0
 ARG cuda_version=12.8
-FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
+ARG api_version=1.10.0
+FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-api${api_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
-ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
-# https://civitai.com/models/4384/dreamshaper
-COPY models/dreamshaper_8.safetensors ${CHECKPOINT_DIR}/
+COPY manifests/dreamshaper8.yml /app/manifest.yml
+ENV MANIFEST=/app/manifest.yml
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
 COPY warmups/dreamshaper8.json warmup.json
@@ -15,13 +14,3 @@ ENV WARMUP_PROMPT_FILE=warmup.json
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
 COPY workflows/dreamshaper8 ${WORKFLOW_DIR}
-
-ENV STARTUP_CHECK_MAX_TRIES=30
-
-# Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.2
-ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
-RUN chmod +x comfyui-api
-
-# Set CMD to launch the comfyui-api binary. The comfyui-api binary will launch ComfyUI as a child process.
-CMD ["./comfyui-api"]

--- a/recipes/comfyui/Dockerfile.dreamshaper8
+++ b/recipes/comfyui/Dockerfile.dreamshaper8
@@ -1,7 +1,7 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.40
-ARG torch_version=2.7.1
-ARG cuda_version=12.6
+ARG comfy_version=0.3.61
+ARG torch_version=2.8.0
+ARG cuda_version=12.8
 FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
 ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
@@ -9,8 +9,8 @@ ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
 COPY models/dreamshaper_8.safetensors ${CHECKPOINT_DIR}/
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
-COPY workflow.json .
-ENV WARMUP_PROMPT_FILE=workflow.json
+COPY warmups/dreamshaper8.json warmup.json
+ENV WARMUP_PROMPT_FILE=warmup.json
 
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
@@ -19,7 +19,7 @@ COPY workflows/dreamshaper8 ${WORKFLOW_DIR}
 ENV STARTUP_CHECK_MAX_TRIES=30
 
 # Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.0
+ARG api_version=1.9.2
 ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
 RUN chmod +x comfyui-api
 

--- a/recipes/comfyui/Dockerfile.flux1dev
+++ b/recipes/comfyui/Dockerfile.flux1dev
@@ -1,7 +1,7 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.40
-ARG torch_version=2.7.1
-ARG cuda_version=12.6
+ARG comfy_version=0.3.61
+ARG torch_version=2.8.0
+ARG cuda_version=12.8
 FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
 ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
@@ -9,8 +9,8 @@ ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
 COPY models/flux1-dev-fp8.safetensors ${CHECKPOINT_DIR}/
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
-COPY workflow.json .
-ENV WARMUP_PROMPT_FILE=workflow.json
+COPY warmups/fluxdev.json warmup.json
+ENV WARMUP_PROMPT_FILE=warmup.json
 
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
@@ -19,7 +19,7 @@ COPY workflows/flux1dev ${WORKFLOW_DIR}
 ENV STARTUP_CHECK_MAX_TRIES=30
 
 # Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.0
+ARG api_version=1.9.2
 ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
 RUN chmod +x comfyui-api
 

--- a/recipes/comfyui/Dockerfile.flux1dev
+++ b/recipes/comfyui/Dockerfile.flux1dev
@@ -1,12 +1,11 @@
-# We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.61
+ARG comfy_version=0.3.62
 ARG torch_version=2.8.0
 ARG cuda_version=12.8
-FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
+ARG api_version=1.10.0
+FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-api${api_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
-ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
-# https://huggingface.co/Comfy-Org/flux1-dev
-COPY models/flux1-dev-fp8.safetensors ${CHECKPOINT_DIR}/
+COPY manifests/flux1dev.yml /app/manifest.yml
+ENV MANIFEST=/app/manifest.yml
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
 COPY warmups/fluxdev.json warmup.json
@@ -15,13 +14,3 @@ ENV WARMUP_PROMPT_FILE=warmup.json
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
 COPY workflows/flux1dev ${WORKFLOW_DIR}
-
-ENV STARTUP_CHECK_MAX_TRIES=30
-
-# Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.2
-ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
-RUN chmod +x comfyui-api
-
-# Set CMD to launch the comfyui-api binary. The comfyui-api binary will launch ComfyUI as a child process.
-CMD ["./comfyui-api"]

--- a/recipes/comfyui/Dockerfile.flux1schnell
+++ b/recipes/comfyui/Dockerfile.flux1schnell
@@ -1,7 +1,7 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.40
-ARG torch_version=2.7.1
-ARG cuda_version=12.6
+ARG comfy_version=0.3.61
+ARG torch_version=2.8.0
+ARG cuda_version=12.8
 FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
 ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
@@ -9,8 +9,8 @@ ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
 COPY models/flux1-schnell-fp8.safetensors ${CHECKPOINT_DIR}/
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
-COPY workflow.json .
-ENV WARMUP_PROMPT_FILE=workflow.json
+COPY warmups/flux1schnell.json warmup.json
+ENV WARMUP_PROMPT_FILE=warmup.json
 
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
@@ -19,7 +19,7 @@ COPY workflows/flux1schnell ${WORKFLOW_DIR}
 ENV STARTUP_CHECK_MAX_TRIES=30
 
 # Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.0
+ARG api_version=1.9.2
 ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
 RUN chmod +x comfyui-api
 

--- a/recipes/comfyui/Dockerfile.flux1schnell
+++ b/recipes/comfyui/Dockerfile.flux1schnell
@@ -1,12 +1,12 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.61
+ARG comfy_version=0.3.62
 ARG torch_version=2.8.0
 ARG cuda_version=12.8
-FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
+ARG api_version=1.10.0
+FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-api${api_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
-ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
-# https://huggingface.co/Comfy-Org/flux1-schnell
-COPY models/flux1-schnell-fp8.safetensors ${CHECKPOINT_DIR}/
+COPY manifests/flux1schnell.yml /app/manifest.yml
+ENV MANIFEST=/app/manifest.yml
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
 COPY warmups/fluxschnell.json warmup.json
@@ -15,13 +15,3 @@ ENV WARMUP_PROMPT_FILE=warmup.json
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
 COPY workflows/flux1schnell ${WORKFLOW_DIR}
-
-ENV STARTUP_CHECK_MAX_TRIES=30
-
-# Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.2
-ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
-RUN chmod +x comfyui-api
-
-# Set CMD to launch the comfyui-api binary. The comfyui-api binary will launch ComfyUI as a child process.
-CMD ["./comfyui-api"]

--- a/recipes/comfyui/Dockerfile.flux1schnell
+++ b/recipes/comfyui/Dockerfile.flux1schnell
@@ -9,7 +9,7 @@ ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
 COPY models/flux1-schnell-fp8.safetensors ${CHECKPOINT_DIR}/
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
-COPY warmups/flux1schnell.json warmup.json
+COPY warmups/fluxschnell.json warmup.json
 ENV WARMUP_PROMPT_FILE=warmup.json
 
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.

--- a/recipes/comfyui/Dockerfile.sd35medium
+++ b/recipes/comfyui/Dockerfile.sd35medium
@@ -1,22 +1,12 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.61
+ARG comfy_version=0.3.62
 ARG torch_version=2.8.0
 ARG cuda_version=12.8
-FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
+ARG api_version=1.10.0
+FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-api${api_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
-ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
-ENV CLIP_DIR=${MODEL_DIR}/clip
-# https://huggingface.co/stabilityai/stable-diffusion-3.5-medium
-COPY models/sd3.5_medium.safetensors ${CHECKPOINT_DIR}/
-
-# https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/blob/main/text_encoders/clip_g.safetensors
-COPY models/clip_g.safetensors ${CLIP_DIR}/
-
-# https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/blob/main/text_encoders/clip_l.safetensors
-COPY models/clip_l.safetensors ${CLIP_DIR}/
-
-# https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/blob/main/text_encoders/t5xxl_fp8_e4m3fn_scaled.safetensors
-COPY models/t5xxl_fp8_e4m3fn_scaled.safetensors ${CLIP_DIR}/
+COPY manifests/sd3.5-medium.yml /app/manifest.yml
+ENV MANIFEST=/app/manifest.yml
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
 COPY warmups/sd3.5-medium.json warmup.json
@@ -25,13 +15,3 @@ ENV WARMUP_PROMPT_FILE=warmup.json
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
 COPY workflows/sd35medium ${WORKFLOW_DIR}
-
-ENV STARTUP_CHECK_MAX_TRIES=30
-
-# Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.2
-ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
-RUN chmod +x comfyui-api
-
-# Set CMD to launch the comfyui-api binary. The comfyui-api binary will launch ComfyUI as a child process.
-CMD ["./comfyui-api"]

--- a/recipes/comfyui/Dockerfile.sd35medium
+++ b/recipes/comfyui/Dockerfile.sd35medium
@@ -1,7 +1,7 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.40
-ARG torch_version=2.7.1
-ARG cuda_version=12.6
+ARG comfy_version=0.3.61
+ARG torch_version=2.8.0
+ARG cuda_version=12.8
 FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
 ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
@@ -19,8 +19,8 @@ COPY models/clip_l.safetensors ${CLIP_DIR}/
 COPY models/t5xxl_fp8_e4m3fn_scaled.safetensors ${CLIP_DIR}/
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
-COPY workflow.json .
-ENV WARMUP_PROMPT_FILE=workflow.json
+COPY warmups/sd3.5-medium.json warmup.json
+ENV WARMUP_PROMPT_FILE=warmup.json
 
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
@@ -29,7 +29,7 @@ COPY workflows/sd35medium ${WORKFLOW_DIR}
 ENV STARTUP_CHECK_MAX_TRIES=30
 
 # Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.0
+ARG api_version=1.9.2
 ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
 RUN chmod +x comfyui-api
 

--- a/recipes/comfyui/Dockerfile.sdxl
+++ b/recipes/comfyui/Dockerfile.sdxl
@@ -1,15 +1,11 @@
-# We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.61
+ARG comfy_version=0.3.62
 ARG torch_version=2.8.0
 ARG cuda_version=12.8
-FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
+ARG api_version=1.10.0
+FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-api${api_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
-ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
-# https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0
-COPY models/sd_xl_base_1.0.safetensors ${CHECKPOINT_DIR}/
-
-# https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0
-COPY models/sd_xl_refiner_1.0.safetensors ${CHECKPOINT_DIR}/
+COPY manifests/sdxl-with-refiner.yml /app/manifest.yml
+ENV MANIFEST=/app/manifest.yml
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
 COPY warmups/sdxl-with-refiner.json warmup.json
@@ -18,13 +14,3 @@ ENV WARMUP_PROMPT_FILE=warmup.json
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
 COPY workflows/sdxl ${WORKFLOW_DIR}
-
-ENV STARTUP_CHECK_MAX_TRIES=30
-
-# Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.2
-ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
-RUN chmod +x comfyui-api
-
-# Set CMD to launch the comfyui-api binary. The comfyui-api binary will launch ComfyUI as a child process.
-CMD ["./comfyui-api"]

--- a/recipes/comfyui/Dockerfile.sdxl
+++ b/recipes/comfyui/Dockerfile.sdxl
@@ -1,7 +1,7 @@
 # We're going to use this verified comfyui image as a base
-ARG comfy_version=0.3.40
-ARG torch_version=2.7.1
-ARG cuda_version=12.6
+ARG comfy_version=0.3.61
+ARG torch_version=2.8.0
+ARG cuda_version=12.8
 FROM ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-torch${torch_version}-cuda${cuda_version}-runtime
 
 ENV CHECKPOINT_DIR=${MODEL_DIR}/checkpoints
@@ -12,8 +12,8 @@ COPY models/sd_xl_base_1.0.safetensors ${CHECKPOINT_DIR}/
 COPY models/sd_xl_refiner_1.0.safetensors ${CHECKPOINT_DIR}/
 
 # The comfyui wrapper api supports a warmup mode, where it will run a provided workflow before starting the server.
-COPY workflow.json .
-ENV WARMUP_PROMPT_FILE=workflow.json
+COPY warmups/sdxl-with-refiner.json warmup.json
+ENV WARMUP_PROMPT_FILE=warmup.json
 
 # We can add custom endpoints to the comfyui wrapper by populating a workflows directory.
 ENV WORKFLOW_DIR=/workflows
@@ -22,7 +22,7 @@ COPY workflows/sdxl ${WORKFLOW_DIR}
 ENV STARTUP_CHECK_MAX_TRIES=30
 
 # Download the comfyui-api binary, and make it executable
-ARG api_version=1.9.0
+ARG api_version=1.9.2
 ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/${api_version}/comfyui-api .
 RUN chmod +x comfyui-api
 

--- a/recipes/comfyui/build-docker-images.sh
+++ b/recipes/comfyui/build-docker-images.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+
+set -euo pipefail
+
+usage="Usage: $0 --comfy-version <version> --api-version <version> --torch-version <version> --cuda-version <version>"
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --comfy-version) comfy_version="$2"; shift ;;
+        --api-version) api_version="$2"; shift ;;
+        --torch-version) torch_version="$2"; shift ;;
+        --cuda-version) cuda_version="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; echo "$usage"; exit 1 ;;
+    esac
+    shift
+done
+
+if [[ -z "${comfy_version:-}" || -z "${api_version:-}" || -z "${torch_version:-}" || -z "${cuda_version:-}" ]]; then
+    echo "Missing required parameters."
+    echo "$usage"
+    exit 1
+fi
+
+dockerfile_extensions=("dreamshaper8" "flux1dev" "flux1schnell" "sd35medium" "sdxl")
+
+for extension in "${dockerfile_extensions[@]}"; do
+  docker build -t "ghcr.io/saladtechnologies/comfyui-api:comfy${comfy_version}-api${api_version}-torch${torch_version}-cuda${cuda_version}-${extension}" \
+    --build-arg comfy_version="$comfy_version" \
+    --build-arg api_version="$api_version" \
+    --build-arg torch_version="$torch_version" \
+    --build-arg cuda_version="$cuda_version" \
+    -f Dockerfile."$extension" .
+done

--- a/recipes/comfyui/container-group.json
+++ b/recipes/comfyui/container-group.json
@@ -14,19 +14,6 @@
       "storageAmount": 1073741824
     }
   },
-  "livenessProbe": {
-    "failureThreshold": 20,
-    "http": {
-      "headers": [],
-      "path": "/health",
-      "port": 3000,
-      "scheme": "http"
-    },
-    "initialDelaySeconds": 5,
-    "periodSeconds": 6,
-    "successThreshold": 1,
-    "timeoutSeconds": 2
-  },
   "name": "",
   "networking": {
     "auth": true,

--- a/recipes/comfyui/form.description.mdx
+++ b/recipes/comfyui/form.description.mdx
@@ -1,4 +1,4 @@
-Run popular image generation models with [ComfyUI](https://github.com/comfyanonymous/ComfyUI/) and [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api). Model weights are included in the container.
+Run popular image generation models with [ComfyUI](https://github.com/comfyanonymous/ComfyUI/) and [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api). Model weights are downloaded at runtime.
 
 <Callout variation="warning">Ensure your use is permissible under whatever license applies to the model you are using.</Callout>
 

--- a/recipes/comfyui/form.description.mdx
+++ b/recipes/comfyui/form.description.mdx
@@ -59,3 +59,36 @@ Here's an example of doing this in a `LoadImage` node:
   }
 }
 ```
+
+## Manifest
+
+When using the "custom" version of this recipe, you can provide a JSON manifest to download additional dependencies at startup.
+The other variants of this recipe come with a manifest file baked in.
+
+The manifest should follow this structure, and be formatted for a single line in the form field:
+
+```json
+{
+  "apt": [
+    "git"
+  ],
+  "pip": [
+    "numpy"
+  ],
+  "custom_nodes": [
+    "comfyui-videohelpersuite",
+    "https://github.com/kijai/ComfyUI-KJNodes.git"
+  ],
+  "models": {
+    "before_start": [
+      {
+        "url": "https://example.com/model.ckpt",
+        "local_path": "models/checkpoints/model.ckpt"
+      }
+    ],
+    "after_start": []
+  }
+}
+```
+
+For gated models, also provide your HuggingFace token in the form field.

--- a/recipes/comfyui/form.json
+++ b/recipes/comfyui/form.json
@@ -15,7 +15,7 @@
     "container_image_model": {
       "title": "Model",
       "type": "string",
-      "enum": ["dreamshaper8", "stablediffusionxl", "flux1schnell", "flux1dev", "stablediffusion35medium"],
+      "enum": ["dreamshaper8", "stablediffusionxl", "flux1schnell", "flux1dev", "stablediffusion35medium", "custom"],
       "default": "flux1dev"
     },
     "networking_auth": {
@@ -43,7 +43,32 @@
               "pattern": "^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
             }
           }
+        },
+        {
+          "required": ["manifest_json"],
+          "properties": {
+            "container_image_model": {
+              "enum": ["custom"]
+            },
+            "manifest_json": {
+              "title": "Manifest JSON",
+              "description": "A valid manifest json string for downloading custom models and extensions",
+              "type": "string",
+              "default": "{\"apt\":[],\"pip\":[],\"custom_nodes\":[],\"models\":{\"before_start\":[],\"after_start\":[]}}",
+              "maxLength": 4096,
+              "minLength": 1
+            },
+            "container_environment_hf_token": {
+              "title": "HuggingFace Token",
+              "description": "Required for gated models. Must begin with \"hf_\" or \"api_org_\".",
+              "type": "string",
+              "maxLength": 42,
+              "minLength": 37,
+              "pattern": "^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
+            }
+          }
         }
+        
       ]
     }
   }

--- a/recipes/comfyui/form.json
+++ b/recipes/comfyui/form.json
@@ -2,11 +2,7 @@
   "title": "ComfyUI API",
   "description": "$replace",
   "type": "object",
-  "required": [
-    "container_group_name",
-    "container_image_model",
-    "networking_auth"
-  ],
+  "required": ["container_group_name", "container_image_model", "networking_auth"],
   "properties": {
     "container_group_name": {
       "type": "string",
@@ -19,13 +15,7 @@
     "container_image_model": {
       "title": "Model",
       "type": "string",
-      "enum": [
-        "dreamshaper8",
-        "stablediffusionxl",
-        "flux1schnell",
-        "flux1dev",
-        "stablediffusion35medium"
-      ],
+      "enum": ["dreamshaper8", "stablediffusionxl", "flux1schnell", "flux1dev", "stablediffusion35medium"],
       "default": "flux1dev"
     },
     "networking_auth": {
@@ -33,6 +23,28 @@
       "description": "When enabled, requests must include a SaladCloud API Key. When disabled, any anonymous request will be allowed.",
       "type": "boolean",
       "default": true
+    }
+  },
+  "dependencies": {
+    "container_image_model": {
+      "oneOf": [
+        {
+          "required": ["container_environment_hf_token"],
+          "properties": {
+            "container_image_model": {
+              "enum": ["stablediffusion35medium"]
+            },
+            "container_environment_hf_token": {
+              "title": "HuggingFace Token",
+              "description": "Required* Must begin with \"hf_\" or \"api_org_\".",
+              "type": "string",
+              "maxLength": 42,
+              "minLength": 37,
+              "pattern": "^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/recipes/comfyui/manifests/dreamshaper8.yml
+++ b/recipes/comfyui/manifests/dreamshaper8.yml
@@ -1,0 +1,4 @@
+models:
+  before_start:
+    - url: https://civitai.com/api/download/models/128713?type=Model&format=SafeTensor&size=pruned&fp=fp16
+      local_path: models/checkpoints/dreamshaper_8.safetensors

--- a/recipes/comfyui/manifests/flux1dev.yml
+++ b/recipes/comfyui/manifests/flux1dev.yml
@@ -1,0 +1,4 @@
+models:
+  before_start:
+    - url: https://huggingface.co/Comfy-Org/flux1-dev/resolve/main/flux1-dev-fp8.safetensors?download=true
+      local_path: models/checkpoints/flux1-dev-fp8.safetensors

--- a/recipes/comfyui/manifests/flux1schnell.yml
+++ b/recipes/comfyui/manifests/flux1schnell.yml
@@ -1,0 +1,4 @@
+models:
+  before_start:
+    - url: https://huggingface.co/Comfy-Org/flux1-schnell/resolve/main/flux1-schnell-fp8.safetensors?download=true
+      local_path: models/checkpoints/flux1-schnell-fp8.safetensors

--- a/recipes/comfyui/manifests/sd3.5-medium.yml
+++ b/recipes/comfyui/manifests/sd3.5-medium.yml
@@ -1,0 +1,10 @@
+models:
+  before_start:
+    - url: https://huggingface.co/stabilityai/stable-diffusion-3.5-medium/resolve/main/sd3.5_medium.safetensors?download=true
+      local_path: models/checkpoints/sd3.5_medium.safetensors
+    - url: https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/resolve/main/text_encoders/clip_g.safetensors
+      local_path: models/text_encoders/clip_g.safetensors
+    - url: https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/resolve/main/text_encoders/clip_l.safetensors
+      local_path: models/text_encoders/clip_l.safetensors
+    - url: https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/resolve/main/text_encoders/t5xxl_fp8_e4m3fn_scaled.safetensors
+      local_path: models/text_encoders/t5xxl_fp8_e4m3fn.safetensors

--- a/recipes/comfyui/manifests/sdxl-with-refiner.yml
+++ b/recipes/comfyui/manifests/sdxl-with-refiner.yml
@@ -1,0 +1,6 @@
+models:
+  before_start:
+    - url: https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors?download=true
+      local_path: models/checkpoints/sd_xl_base_1.0.safetensors
+    - url: https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0/resolve/main/sd_xl_refiner_1.0.safetensors?download=true
+      local_path: models/checkpoints/sd_xl_refiner_1.0.safetensors

--- a/recipes/comfyui/misc.json
+++ b/recipes/comfyui/misc.json
@@ -6,7 +6,8 @@
         "Stable Diffusion XL",
         "Flux 1 Schnell",
         "Flux 1 Dev",
-        "Stable Diffusion 3.5 Medium"
+        "Stable Diffusion 3.5 Medium",
+        "Custom Manifest"
       ]
     },
     "networking_auth": {

--- a/recipes/comfyui/patches.6.2.readme.mdx
+++ b/recipes/comfyui/patches.6.2.readme.mdx
@@ -1,0 +1,55 @@
+# ComfyUI API - Custom Manifest
+
+## Resources
+
+- <Link url={`https://${props.networking.dns}/docs`}>Swagger Docs</Link> (Needs auth if enabled)
+- [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api)
+- [ComfyUI](https://github.com/comfyanonymous/ComfyUI/)
+- [Recipe Source](https://github.com/SaladTechnologies/salad-recipes/tree/master/recipes/comfyui)
+
+## Request Format
+
+Prompts are submitted to the server via the `POST /prompt` endpoint, which accepts a JSON body containing the prompt graph, as well as any additional optional parameters such as the webhook URL and image conversion options. A request may look something like:
+
+```json
+{"prompt": {}}
+```
+
+- Only the `prompt` field is required. The other fields are optional, and can be omitted if not needed.
+- Your `prompt` must be a valid API-formatted ComfyUI prompt graph, which is a JSON object where each key is a node ID, and the value is an object containing the node's inputs, class type, and optional metadata.
+- Your prompt must include a node that saves an output, such as a `SaveImage` node.
+
+### Curl Example
+
+<Callout variation="note">Requires `curl` and `jq` to be installed.</Callout>
+
+Save your request body to a file called `prompt.json` and run the following command:
+
+<Callout variation="note">If you do not have auth enabled, you can omit the `Salad-Api-Key` header.</Callout>
+
+<CodeBlock language="bash">{`curl -X POST https://${props.networking.dns}/prompt \\
+  -H "Content-Type: application/json" \\
+  -H "Salad-Api-Key: ${props.apiKey}" \\
+  -d @prompt.json | jq -r .images[0] | base64 --decode > output.jpg
+`}</CodeBlock>
+
+The generated image will be saved as `output.jpg` after decoding the base64 response.
+
+## Image To Image Workflows
+
+The ComfyUI API server supports image-to-image workflows, allowing you to submit an image and receive a modified version of that image in response. This is useful for tasks such as image inpainting, style transfer, and other image manipulation tasks.
+
+To use image-to-image workflows, you can submit an image as a base64-encoded string, http(s) URL, or S3 URL. The server will automatically detect the input type and process the image accordingly. If you are using S3, you must customize the deployment to add your AWS credentials to the environment variables.
+
+Here's an example of doing this in a `LoadImage` node:
+
+<CodeBlock language="json">{`{
+  "inputs": {
+    "image": "https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg",
+    "upload": "image"
+  },
+  "class_type": "LoadImage",
+  "_meta": {
+    "title": "Load Image"
+  }
+}`}</CodeBlock>

--- a/recipes/comfyui/patches.json
+++ b/recipes/comfyui/patches.json
@@ -30,7 +30,7 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-dreamshaper8"
+      "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-dreamshaper8"
     },
     {
       "op": "add",
@@ -47,7 +47,7 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-sdxl-with-refiner"
+      "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-sdxl"
     },
     {
       "op": "add",
@@ -64,7 +64,7 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-flux1-schnell-fp8"
+      "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-flux1schnell"
     },
     {
       "op": "add",
@@ -81,7 +81,7 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-flux1-dev-fp8"
+      "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-flux1dev"
     },
     {
       "op": "add",
@@ -98,12 +98,17 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-sd3.5-medium"
+      "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-sd35medium"
     },
     {
       "op": "add",
       "path": "/output/readme",
       "value": "$replace"
+    },
+    {
+      "op": "copy",
+      "from": "/input/container_environment_hf_token",
+      "path": "/output/container/environmentVariables/HF_TOKEN"
     }
   ]
 ]

--- a/recipes/comfyui/patches.json
+++ b/recipes/comfyui/patches.json
@@ -110,5 +110,32 @@
       "from": "/input/container_environment_hf_token",
       "path": "/output/container/environmentVariables/HF_TOKEN"
     }
+  ],
+  [
+    {
+      "op": "test",
+      "path": "/input/container_image_model",
+      "value": "custom"
+    },
+    {
+      "op": "add",
+      "path": "/output/container/image",
+      "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-runtime"
+    },
+    {
+      "op": "add",
+      "path": "/output/readme",
+      "value": "$replace"
+    },
+    {
+      "op": "copy",
+      "from": "/input/manifest_json",
+      "path": "/output/container/environmentVariables/MANIFEST_JSON"
+    },
+    {
+      "op": "copy",
+      "from": "/input/container_environment_hf_token",
+      "path": "/output/container/environmentVariables/HF_TOKEN"
+    }
   ]
 ]

--- a/recipes/comfyui/patches.json
+++ b/recipes/comfyui/patches.json
@@ -30,7 +30,7 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-dreamshaper8"
+      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-dreamshaper8"
     },
     {
       "op": "add",
@@ -47,7 +47,7 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-sdxl-with-refiner"
+      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-sdxl-with-refiner"
     },
     {
       "op": "add",
@@ -64,7 +64,7 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-flux1-schnell-fp8"
+      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-flux1-schnell-fp8"
     },
     {
       "op": "add",
@@ -81,7 +81,7 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-flux1-dev-fp8"
+      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-flux1-dev-fp8"
     },
     {
       "op": "add",
@@ -98,7 +98,7 @@
     {
       "op": "add",
       "path": "/output/container/image",
-      "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-sd3.5-medium"
+      "value": "saladtechnologies/comfyui:comfy0.3.61-api1.9.2-torch2.8.0-cuda12.8-sd3.5-medium"
     },
     {
       "op": "add",

--- a/recipes/comfyui/recipe.json
+++ b/recipes/comfyui/recipe.json
@@ -55,7 +55,7 @@
   },
   "form": {
     "title": "ComfyUI API",
-    "description": "Run popular image generation models with [ComfyUI](https://github.com/comfyanonymous/ComfyUI/) and [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api). Model weights are included in the container.\n\n<Callout variation=\"warning\">Ensure your use is permissible under whatever license applies to the model you are using.</Callout>\n\nThis recipe **DOES NOT** expose the ComfyUI web interface, it only provides the API interface via the [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api).\n\nThe ComfyUI API server is designed to be stateless, meaning that it does not store any state between requests. This allows the server to be scaled horizontally behind a load balancer, and to handle more requests by adding more instances of the server. The server uses a warmup workflow to ensure that ComfyUI is ready to accept requests, and to pre-load any required models. The server also self-hosts swagger docs and an openapi spec at `/docs`, which can be used to interact with the API.\n\n## Request Format\n\nPrompts are submitted to the server via the `POST /prompt` endpoint, which accepts a JSON body containing the prompt graph, as well as any additional parameters such as the webhook URL, S3 bucket and prefix, and image conversion options. A request may look something like:\n\n\n<Callout variation=\"warning\">This is not a complete request body, as it does not include a node that saves an output.</Callout>\n\n```json\n{\n  \"prompt\": {\n    \"1\": {\n      \"inputs\": {\n        \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n        \"upload\": \"image\"\n      },\n      \"class_type\": \"LoadImage\"\n    }\n  },\n  \"webhook\": \"https://example.com/webhook\",\n  \"convert_output\": {\n    \"format\": \"jpeg\",\n    \"options\": {\n      \"quality\": 80,\n      \"progressive\": true\n    }\n  }\n}\n```\n\n- Only the `prompt` field is required. The other fields are optional, and can be omitted if not needed.\n- Your prompt must be a valid ComfyUI prompt graph, which is a JSON object where each key is a node ID, and the value is an object containing the node's inputs, class type, and optional metadata.\n- Your prompt must include a node that saves an output, such as a `SaveImage` node.\n\n## Image To Image Workflows\n\nThe ComfyUI API server supports image-to-image workflows, allowing you to submit an image and receive a modified version of that image in response. This is useful for tasks such as image inpainting, style transfer, and other image manipulation tasks.\n\nTo use image-to-image workflows, you can submit an image as a base64-encoded string, http(s) URL, or S3 URL. The server will automatically detect the input type and process the image accordingly. If you are using S3, you must customize the deployment to add your AWS credentials to the environment variables.\n\nHere's an example of doing this in a `LoadImage` node:\n\n```json\n{\n  \"inputs\": {\n    \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n    \"upload\": \"image\"\n  },\n  \"class_type\": \"LoadImage\",\n  \"_meta\": {\n    \"title\": \"Load Image\"\n  }\n}\n```",
+    "description": "Run popular image generation models with [ComfyUI](https://github.com/comfyanonymous/ComfyUI/) and [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api). Model weights are downloaded at runtime.\n\n<Callout variation=\"warning\">Ensure your use is permissible under whatever license applies to the model you are using.</Callout>\n\nThis recipe **DOES NOT** expose the ComfyUI web interface, it only provides the API interface via the [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api).\n\nThe ComfyUI API server is designed to be stateless, meaning that it does not store any state between requests. This allows the server to be scaled horizontally behind a load balancer, and to handle more requests by adding more instances of the server. The server uses a warmup workflow to ensure that ComfyUI is ready to accept requests, and to pre-load any required models. The server also self-hosts swagger docs and an openapi spec at `/docs`, which can be used to interact with the API.\n\n## Request Format\n\nPrompts are submitted to the server via the `POST /prompt` endpoint, which accepts a JSON body containing the prompt graph, as well as any additional parameters such as the webhook URL, S3 bucket and prefix, and image conversion options. A request may look something like:\n\n\n<Callout variation=\"warning\">This is not a complete request body, as it does not include a node that saves an output.</Callout>\n\n```json\n{\n  \"prompt\": {\n    \"1\": {\n      \"inputs\": {\n        \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n        \"upload\": \"image\"\n      },\n      \"class_type\": \"LoadImage\"\n    }\n  },\n  \"webhook\": \"https://example.com/webhook\",\n  \"convert_output\": {\n    \"format\": \"jpeg\",\n    \"options\": {\n      \"quality\": 80,\n      \"progressive\": true\n    }\n  }\n}\n```\n\n- Only the `prompt` field is required. The other fields are optional, and can be omitted if not needed.\n- Your prompt must be a valid ComfyUI prompt graph, which is a JSON object where each key is a node ID, and the value is an object containing the node's inputs, class type, and optional metadata.\n- Your prompt must include a node that saves an output, such as a `SaveImage` node.\n\n## Image To Image Workflows\n\nThe ComfyUI API server supports image-to-image workflows, allowing you to submit an image and receive a modified version of that image in response. This is useful for tasks such as image inpainting, style transfer, and other image manipulation tasks.\n\nTo use image-to-image workflows, you can submit an image as a base64-encoded string, http(s) URL, or S3 URL. The server will automatically detect the input type and process the image accordingly. If you are using S3, you must customize the deployment to add your AWS credentials to the environment variables.\n\nHere's an example of doing this in a `LoadImage` node:\n\n```json\n{\n  \"inputs\": {\n    \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n    \"upload\": \"image\"\n  },\n  \"class_type\": \"LoadImage\",\n  \"_meta\": {\n    \"title\": \"Load Image\"\n  }\n}\n```",
     "type": "object",
     "required": ["container_group_name", "container_image_model", "networking_auth"],
     "properties": {
@@ -78,6 +78,28 @@
         "description": "When enabled, requests must include a SaladCloud API Key. When disabled, any anonymous request will be allowed.",
         "type": "boolean",
         "default": true
+      }
+    },
+    "dependencies": {
+      "container_image_model": {
+        "oneOf": [
+          {
+            "required": ["container_environment_hf_token"],
+            "properties": {
+              "container_image_model": {
+                "enum": ["stablediffusion35medium"]
+              },
+              "container_environment_hf_token": {
+                "title": "HuggingFace Token",
+                "description": "Required* Must begin with \"hf_\" or \"api_org_\".",
+                "type": "string",
+                "maxLength": 42,
+                "minLength": 37,
+                "pattern": "^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
+              }
+            }
+          }
+        ]
       }
     }
   },
@@ -113,7 +135,7 @@
       {
         "op": "add",
         "path": "/output/container/image",
-        "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-dreamshaper8"
+        "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-dreamshaper8"
       },
       {
         "op": "add",
@@ -130,7 +152,7 @@
       {
         "op": "add",
         "path": "/output/container/image",
-        "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-sdxl-with-refiner"
+        "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-sdxl"
       },
       {
         "op": "add",
@@ -147,7 +169,7 @@
       {
         "op": "add",
         "path": "/output/container/image",
-        "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-flux1-schnell-fp8"
+        "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-flux1schnell"
       },
       {
         "op": "add",
@@ -164,7 +186,7 @@
       {
         "op": "add",
         "path": "/output/container/image",
-        "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-flux1-dev-fp8"
+        "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-flux1dev"
       },
       {
         "op": "add",
@@ -181,12 +203,17 @@
       {
         "op": "add",
         "path": "/output/container/image",
-        "value": "saladtechnologies/comfyui:comfy0.3.40-api1.9.0-torch2.7.1-cuda12.6-sd3.5-medium"
+        "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-sd35medium"
       },
       {
         "op": "add",
         "path": "/output/readme",
         "value": "# ComfyUI API - Stable Diffusion 3.5 Medium\n\n## Resources\n\n- <Link url={`https://${props.networking.dns}/docs`}>Swagger Docs</Link> (Needs auth if enabled)\n- [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api)\n- [ComfyUI](https://github.com/comfyanonymous/ComfyUI/)\n- [Stable Diffusion 3.5 Medium](https://huggingface.co/stabilityai/stable-diffusion-3.5-medium)\n- [Recipe Source](https://github.com/SaladTechnologies/salad-recipes/tree/master/recipes/comfyui)\n- <Link url={`https://github.com/SaladTechnologies/salad-recipes/issues/new?title=ComfyUI%20API%20-%20Stable%20Diffusion%203.5%20Medium&body=%3C%21---%20Please%20describe%20the%20issue%20you%20are%20having%20with%20this%20recipe%2C%20and%20include%20as%20much%20detail%20as%20possible%2C%20including%20any%20relevant%20logs.%20--%3E%0AImage%3A%20${props.container.image}`}>Report an Issue on GitHub</Link>\n\n## Request Format\n\nPrompts are submitted to the server via the `POST /prompt` endpoint, which accepts a JSON body containing the prompt graph, as well as any additional optional parameters such as the webhook URL and image conversion options. A request may look something like:\n\n<CodeBlock language=\"json\">{`{\n    \"prompt\": {\n        \"4\": {\n            \"inputs\": {\n                \"ckpt_name\": \"sd3.5_medium.safetensors\"\n            },\n            \"class_type\": \"CheckpointLoaderSimple\",\n            \"_meta\": {\n                \"title\": \"Load Checkpoint\"\n            }\n        },\n        \"6\": {\n            \"inputs\": {\n                \"text\": \"beautiful scenery nature glass bottle landscape, purple galaxy bottle,\",\n                \"clip\": [\n                    \"11\",\n                    0\n                ]\n            },\n            \"class_type\": \"CLIPTextEncode\",\n            \"_meta\": {\n                \"title\": \"CLIP Text Encode (Prompt)\"\n            }\n        },\n        \"8\": {\n            \"inputs\": {\n                \"samples\": [\n                    \"294\",\n                    0\n                ],\n                \"vae\": [\n                    \"4\",\n                    2\n                ]\n            },\n            \"class_type\": \"VAEDecode\",\n            \"_meta\": {\n                \"title\": \"VAE Decode\"\n            }\n        },\n        \"11\": {\n            \"inputs\": {\n                \"clip_name1\": \"clip_g.safetensors\",\n                \"clip_name2\": \"clip_l.safetensors\",\n                \"clip_name3\": \"t5xxl_fp8_e4m3fn.safetensors\"\n            },\n            \"class_type\": \"TripleCLIPLoader\",\n            \"_meta\": {\n                \"title\": \"TripleCLIPLoader\"\n            }\n        },\n        \"13\": {\n            \"inputs\": {\n                \"shift\": 3,\n                \"model\": [\n                    \"4\",\n                    0\n                ]\n            },\n            \"class_type\": \"ModelSamplingSD3\",\n            \"_meta\": {\n                \"title\": \"ModelSamplingSD3\"\n            }\n        },\n        \"67\": {\n            \"inputs\": {\n                \"conditioning\": [\n                    \"71\",\n                    0\n                ]\n            },\n            \"class_type\": \"ConditioningZeroOut\",\n            \"_meta\": {\n                \"title\": \"ConditioningZeroOut\"\n            }\n        },\n        \"68\": {\n            \"inputs\": {\n                \"start\": 0.1,\n                \"end\": 1,\n                \"conditioning\": [\n                    \"67\",\n                    0\n                ]\n            },\n            \"class_type\": \"ConditioningSetTimestepRange\",\n            \"_meta\": {\n                \"title\": \"ConditioningSetTimestepRange\"\n            }\n        },\n        \"69\": {\n            \"inputs\": {\n                \"conditioning_1\": [\n                    \"68\",\n                    0\n                ],\n                \"conditioning_2\": [\n                    \"70\",\n                    0\n                ]\n            },\n            \"class_type\": \"ConditioningCombine\",\n            \"_meta\": {\n                \"title\": \"Conditioning (Combine)\"\n            }\n        },\n        \"70\": {\n            \"inputs\": {\n                \"start\": 0,\n                \"end\": 0.1,\n                \"conditioning\": [\n                    \"71\",\n                    0\n                ]\n            },\n            \"class_type\": \"ConditioningSetTimestepRange\",\n            \"_meta\": {\n                \"title\": \"ConditioningSetTimestepRange\"\n            }\n        },\n        \"71\": {\n            \"inputs\": {\n                \"text\": \"\",\n                \"clip\": [\n                    \"11\",\n                    0\n                ]\n            },\n            \"class_type\": \"CLIPTextEncode\",\n            \"_meta\": {\n                \"title\": \"CLIP Text Encode (Prompt)\"\n            }\n        },\n        \"135\": {\n            \"inputs\": {\n                \"width\": 1024,\n                \"height\": 1024,\n                \"batch_size\": 1\n            },\n            \"class_type\": \"EmptySD3LatentImage\",\n            \"_meta\": {\n                \"title\": \"EmptySD3LatentImage\"\n            }\n        },\n        \"294\": {\n            \"inputs\": {\n                \"seed\": 998428620595727,\n                \"steps\": 20,\n                \"cfg\": 4.5,\n                \"sampler_name\": \"dpmpp_2m\",\n                \"scheduler\": \"sgm_uniform\",\n                \"denoise\": 1,\n                \"model\": [\n                    \"13\",\n                    0\n                ],\n                \"positive\": [\n                    \"6\",\n                    0\n                ],\n                \"negative\": [\n                    \"69\",\n                    0\n                ],\n                \"latent_image\": [\n                    \"135\",\n                    0\n                ]\n            },\n            \"class_type\": \"KSampler\",\n            \"_meta\": {\n                \"title\": \"KSampler\"\n            }\n        },\n        \"301\": {\n            \"inputs\": {\n                \"filename_prefix\": \"ComfyUI\",\n                \"images\": [\n                    \"8\",\n                    0\n                ]\n            },\n            \"class_type\": \"SaveImage\",\n            \"_meta\": {\n                \"title\": \"Save Image\"\n            }\n        }\n    },\n    \"webhook\": \"https://example.com/webhook\",\n    \"convert_output\": {\n        \"format\": \"jpeg\",\n        \"options\": {\n            \"quality\": 80,\n            \"progressive\": true\n        }\n    }\n}`}</CodeBlock>\n\n\n- Only the `prompt` field is required. The other fields are optional, and can be omitted if not needed.\n- Your `prompt` must be a valid API-formatted ComfyUI prompt graph, which is a JSON object where each key is a node ID, and the value is an object containing the node's inputs, class type, and optional metadata.\n- Your prompt must include a node that saves an output, such as a `SaveImage` node.\n\n### Curl Example\n\n<Callout variation=\"note\">Requires `curl` and `jq` to be installed.</Callout>\n\nSave your request body to a file called `prompt.json` and run the following command:\n\n<Callout variation=\"note\">If you do not have auth enabled, you can omit the `Salad-Api-Key` header.</Callout>\n\n<CodeBlock language=\"bash\">{`curl -X POST https://${props.networking.dns}/prompt \\\\\n  -H \"Content-Type: application/json\" \\\\\n  -H \"Salad-Api-Key: ${props.apiKey}\" \\\\\n  -d @prompt.json | jq -r .images[0] | base64 --decode > output.jpg\n`}</CodeBlock>\n\nThe generated image will be saved as `output.jpg` after decoding the base64 response.\n\n## Image To Image Workflows\n\nThe ComfyUI API server supports image-to-image workflows, allowing you to submit an image and receive a modified version of that image in response. This is useful for tasks such as image inpainting, style transfer, and other image manipulation tasks.\n\nTo use image-to-image workflows, you can submit an image as a base64-encoded string, http(s) URL, or S3 URL. The server will automatically detect the input type and process the image accordingly. If you are using S3, you must customize the deployment to add your AWS credentials to the environment variables.\n\nHere's an example of doing this in a `LoadImage` node:\n\n<CodeBlock language=\"json\">{`{\n  \"inputs\": {\n    \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n    \"upload\": \"image\"\n  },\n  \"class_type\": \"LoadImage\",\n  \"_meta\": {\n    \"title\": \"Load Image\"\n  }\n}`}</CodeBlock>\n"
+      },
+      {
+        "op": "copy",
+        "from": "/input/container_environment_hf_token",
+        "path": "/output/container/environmentVariables/HF_TOKEN"
       }
     ]
   ],

--- a/recipes/comfyui/recipe.json
+++ b/recipes/comfyui/recipe.json
@@ -42,7 +42,7 @@
   },
   "form": {
     "title": "ComfyUI API",
-    "description": "Run popular image generation models with [ComfyUI](https://github.com/comfyanonymous/ComfyUI/) and [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api). Model weights are downloaded at runtime.\n\n<Callout variation=\"warning\">Ensure your use is permissible under whatever license applies to the model you are using.</Callout>\n\nThis recipe **DOES NOT** expose the ComfyUI web interface, it only provides the API interface via the [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api).\n\nThe ComfyUI API server is designed to be stateless, meaning that it does not store any state between requests. This allows the server to be scaled horizontally behind a load balancer, and to handle more requests by adding more instances of the server. The server uses a warmup workflow to ensure that ComfyUI is ready to accept requests, and to pre-load any required models. The server also self-hosts swagger docs and an openapi spec at `/docs`, which can be used to interact with the API.\n\n## Request Format\n\nPrompts are submitted to the server via the `POST /prompt` endpoint, which accepts a JSON body containing the prompt graph, as well as any additional parameters such as the webhook URL, S3 bucket and prefix, and image conversion options. A request may look something like:\n\n\n<Callout variation=\"warning\">This is not a complete request body, as it does not include a node that saves an output.</Callout>\n\n```json\n{\n  \"prompt\": {\n    \"1\": {\n      \"inputs\": {\n        \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n        \"upload\": \"image\"\n      },\n      \"class_type\": \"LoadImage\"\n    }\n  },\n  \"webhook\": \"https://example.com/webhook\",\n  \"convert_output\": {\n    \"format\": \"jpeg\",\n    \"options\": {\n      \"quality\": 80,\n      \"progressive\": true\n    }\n  }\n}\n```\n\n- Only the `prompt` field is required. The other fields are optional, and can be omitted if not needed.\n- Your prompt must be a valid ComfyUI prompt graph, which is a JSON object where each key is a node ID, and the value is an object containing the node's inputs, class type, and optional metadata.\n- Your prompt must include a node that saves an output, such as a `SaveImage` node.\n\n## Image To Image Workflows\n\nThe ComfyUI API server supports image-to-image workflows, allowing you to submit an image and receive a modified version of that image in response. This is useful for tasks such as image inpainting, style transfer, and other image manipulation tasks.\n\nTo use image-to-image workflows, you can submit an image as a base64-encoded string, http(s) URL, or S3 URL. The server will automatically detect the input type and process the image accordingly. If you are using S3, you must customize the deployment to add your AWS credentials to the environment variables.\n\nHere's an example of doing this in a `LoadImage` node:\n\n```json\n{\n  \"inputs\": {\n    \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n    \"upload\": \"image\"\n  },\n  \"class_type\": \"LoadImage\",\n  \"_meta\": {\n    \"title\": \"Load Image\"\n  }\n}\n```",
+    "description": "Run popular image generation models with [ComfyUI](https://github.com/comfyanonymous/ComfyUI/) and [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api). Model weights are downloaded at runtime.\n\n<Callout variation=\"warning\">Ensure your use is permissible under whatever license applies to the model you are using.</Callout>\n\nThis recipe **DOES NOT** expose the ComfyUI web interface, it only provides the API interface via the [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api).\n\nThe ComfyUI API server is designed to be stateless, meaning that it does not store any state between requests. This allows the server to be scaled horizontally behind a load balancer, and to handle more requests by adding more instances of the server. The server uses a warmup workflow to ensure that ComfyUI is ready to accept requests, and to pre-load any required models. The server also self-hosts swagger docs and an openapi spec at `/docs`, which can be used to interact with the API.\n\n## Request Format\n\nPrompts are submitted to the server via the `POST /prompt` endpoint, which accepts a JSON body containing the prompt graph, as well as any additional parameters such as the webhook URL, S3 bucket and prefix, and image conversion options. A request may look something like:\n\n\n<Callout variation=\"warning\">This is not a complete request body, as it does not include a node that saves an output.</Callout>\n\n```json\n{\n  \"prompt\": {\n    \"1\": {\n      \"inputs\": {\n        \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n        \"upload\": \"image\"\n      },\n      \"class_type\": \"LoadImage\"\n    }\n  },\n  \"webhook\": \"https://example.com/webhook\",\n  \"convert_output\": {\n    \"format\": \"jpeg\",\n    \"options\": {\n      \"quality\": 80,\n      \"progressive\": true\n    }\n  }\n}\n```\n\n- Only the `prompt` field is required. The other fields are optional, and can be omitted if not needed.\n- Your prompt must be a valid ComfyUI prompt graph, which is a JSON object where each key is a node ID, and the value is an object containing the node's inputs, class type, and optional metadata.\n- Your prompt must include a node that saves an output, such as a `SaveImage` node.\n\n## Image To Image Workflows\n\nThe ComfyUI API server supports image-to-image workflows, allowing you to submit an image and receive a modified version of that image in response. This is useful for tasks such as image inpainting, style transfer, and other image manipulation tasks.\n\nTo use image-to-image workflows, you can submit an image as a base64-encoded string, http(s) URL, or S3 URL. The server will automatically detect the input type and process the image accordingly. If you are using S3, you must customize the deployment to add your AWS credentials to the environment variables.\n\nHere's an example of doing this in a `LoadImage` node:\n\n```json\n{\n  \"inputs\": {\n    \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n    \"upload\": \"image\"\n  },\n  \"class_type\": \"LoadImage\",\n  \"_meta\": {\n    \"title\": \"Load Image\"\n  }\n}\n```\n\n## Manifest\n\nWhen using the \"custom\" version of this recipe, you can provide a JSON manifest to download additional dependencies at startup.\nThe other variants of this recipe come with a manifest file baked in.\n\nThe manifest should follow this structure, and be formatted for a single line in the form field:\n\n```json\n{\n  \"apt\": [\n    \"git\"\n  ],\n  \"pip\": [\n    \"numpy\"\n  ],\n  \"custom_nodes\": [\n    \"comfyui-videohelpersuite\",\n    \"https://github.com/kijai/ComfyUI-KJNodes.git\"\n  ],\n  \"models\": {\n    \"before_start\": [\n      {\n        \"url\": \"https://example.com/model.ckpt\",\n        \"local_path\": \"models/checkpoints/model.ckpt\"\n      }\n    ],\n    \"after_start\": []\n  }\n}\n```\n\nFor gated models, also provide your HuggingFace token in the form field.",
     "type": "object",
     "required": ["container_group_name", "container_image_model", "networking_auth"],
     "properties": {
@@ -57,7 +57,7 @@
       "container_image_model": {
         "title": "Model",
         "type": "string",
-        "enum": ["dreamshaper8", "stablediffusionxl", "flux1schnell", "flux1dev", "stablediffusion35medium"],
+        "enum": ["dreamshaper8", "stablediffusionxl", "flux1schnell", "flux1dev", "stablediffusion35medium", "custom"],
         "default": "flux1dev"
       },
       "networking_auth": {
@@ -79,6 +79,30 @@
               "container_environment_hf_token": {
                 "title": "HuggingFace Token",
                 "description": "Required* Must begin with \"hf_\" or \"api_org_\".",
+                "type": "string",
+                "maxLength": 42,
+                "minLength": 37,
+                "pattern": "^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
+              }
+            }
+          },
+          {
+            "required": ["manifest_json"],
+            "properties": {
+              "container_image_model": {
+                "enum": ["custom"]
+              },
+              "manifest_json": {
+                "title": "Manifest JSON",
+                "description": "A valid manifest json string for downloading custom models and extensions",
+                "type": "string",
+                "default": "{\"apt\":[],\"pip\":[],\"custom_nodes\":[],\"models\":{\"before_start\":[],\"after_start\":[]}}",
+                "maxLength": 4096,
+                "minLength": 1
+              },
+              "container_environment_hf_token": {
+                "title": "HuggingFace Token",
+                "description": "Required for gated models. Must begin with \"hf_\" or \"api_org_\".",
                 "type": "string",
                 "maxLength": 42,
                 "minLength": 37,
@@ -202,6 +226,33 @@
         "from": "/input/container_environment_hf_token",
         "path": "/output/container/environmentVariables/HF_TOKEN"
       }
+    ],
+    [
+      {
+        "op": "test",
+        "path": "/input/container_image_model",
+        "value": "custom"
+      },
+      {
+        "op": "add",
+        "path": "/output/container/image",
+        "value": "ghcr.io/saladtechnologies/comfyui-api:comfy0.3.62-api1.10.0-torch2.8.0-cuda12.8-runtime"
+      },
+      {
+        "op": "add",
+        "path": "/output/readme",
+        "value": "# ComfyUI API - Custom Manifest\n\n## Resources\n\n- <Link url={`https://${props.networking.dns}/docs`}>Swagger Docs</Link> (Needs auth if enabled)\n- [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api)\n- [ComfyUI](https://github.com/comfyanonymous/ComfyUI/)\n- [Recipe Source](https://github.com/SaladTechnologies/salad-recipes/tree/master/recipes/comfyui)\n\n## Request Format\n\nPrompts are submitted to the server via the `POST /prompt` endpoint, which accepts a JSON body containing the prompt graph, as well as any additional optional parameters such as the webhook URL and image conversion options. A request may look something like:\n\n```json\n{\"prompt\": {}}\n```\n\n- Only the `prompt` field is required. The other fields are optional, and can be omitted if not needed.\n- Your `prompt` must be a valid API-formatted ComfyUI prompt graph, which is a JSON object where each key is a node ID, and the value is an object containing the node's inputs, class type, and optional metadata.\n- Your prompt must include a node that saves an output, such as a `SaveImage` node.\n\n### Curl Example\n\n<Callout variation=\"note\">Requires `curl` and `jq` to be installed.</Callout>\n\nSave your request body to a file called `prompt.json` and run the following command:\n\n<Callout variation=\"note\">If you do not have auth enabled, you can omit the `Salad-Api-Key` header.</Callout>\n\n<CodeBlock language=\"bash\">{`curl -X POST https://${props.networking.dns}/prompt \\\\\n  -H \"Content-Type: application/json\" \\\\\n  -H \"Salad-Api-Key: ${props.apiKey}\" \\\\\n  -d @prompt.json | jq -r .images[0] | base64 --decode > output.jpg\n`}</CodeBlock>\n\nThe generated image will be saved as `output.jpg` after decoding the base64 response.\n\n## Image To Image Workflows\n\nThe ComfyUI API server supports image-to-image workflows, allowing you to submit an image and receive a modified version of that image in response. This is useful for tasks such as image inpainting, style transfer, and other image manipulation tasks.\n\nTo use image-to-image workflows, you can submit an image as a base64-encoded string, http(s) URL, or S3 URL. The server will automatically detect the input type and process the image accordingly. If you are using S3, you must customize the deployment to add your AWS credentials to the environment variables.\n\nHere's an example of doing this in a `LoadImage` node:\n\n<CodeBlock language=\"json\">{`{\n  \"inputs\": {\n    \"image\": \"https://salad-benchmark-assets.download/coco2017/train2017/000000000009.jpg\",\n    \"upload\": \"image\"\n  },\n  \"class_type\": \"LoadImage\",\n  \"_meta\": {\n    \"title\": \"Load Image\"\n  }\n}`}</CodeBlock>\n"
+      },
+      {
+        "op": "copy",
+        "from": "/input/manifest_json",
+        "path": "/output/container/environmentVariables/MANIFEST_JSON"
+      },
+      {
+        "op": "copy",
+        "from": "/input/container_environment_hf_token",
+        "path": "/output/container/environmentVariables/HF_TOKEN"
+      }
     ]
   ],
   "ui": {
@@ -211,7 +262,8 @@
         "Stable Diffusion XL",
         "Flux 1 Schnell",
         "Flux 1 Dev",
-        "Stable Diffusion 3.5 Medium"
+        "Stable Diffusion 3.5 Medium",
+        "Custom Manifest"
       ]
     },
     "networking_auth": {

--- a/recipes/comfyui/recipe.json
+++ b/recipes/comfyui/recipe.json
@@ -13,19 +13,6 @@
         "storageAmount": 1073741824
       }
     },
-    "livenessProbe": {
-      "failureThreshold": 20,
-      "http": {
-        "headers": [],
-        "path": "/health",
-        "port": 3000,
-        "scheme": "http"
-      },
-      "initialDelaySeconds": 5,
-      "periodSeconds": 6,
-      "successThreshold": 1,
-      "timeoutSeconds": 2
-    },
     "name": "",
     "networking": {
       "auth": true,

--- a/recipes/comfyui/warmups/dreamshaper8.json
+++ b/recipes/comfyui/warmups/dreamshaper8.json
@@ -1,0 +1,107 @@
+{
+  "3": {
+    "inputs": {
+      "seed": 712610403220747,
+      "steps": 20,
+      "cfg": 8,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1,
+      "model": [
+        "4",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "4": {
+    "inputs": {
+      "ckpt_name": "dreamshaper_8.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "5": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "Empty Latent Image"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "beautiful scenery nature glass bottle landscape, , purple galaxy bottle,",
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "text, watermark",
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/recipes/comfyui/warmups/fluxdev.json
+++ b/recipes/comfyui/warmups/fluxdev.json
@@ -1,0 +1,120 @@
+{
+  "6": {
+    "inputs": {
+      "text": "leafy green spaceship descending from orbit into a luch bio-organic cityscape. the sky is pale purple, and red storm clouds form in the distance, crackling with lightning.",
+      "clip": [
+        "30",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "31",
+        0
+      ],
+      "vae": [
+        "30",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "27": {
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "class_type": "EmptySD3LatentImage",
+    "_meta": {
+      "title": "EmptySD3LatentImage"
+    }
+  },
+  "30": {
+    "inputs": {
+      "ckpt_name": "flux1-dev-fp8.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "31": {
+    "inputs": {
+      "seed": 793373912447585,
+      "steps": 20,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1,
+      "model": [
+        "30",
+        0
+      ],
+      "positive": [
+        "35",
+        0
+      ],
+      "negative": [
+        "33",
+        0
+      ],
+      "latent_image": [
+        "27",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "33": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "30",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "35": {
+    "inputs": {
+      "guidance": 3.5,
+      "conditioning": [
+        "6",
+        0
+      ]
+    },
+    "class_type": "FluxGuidance",
+    "_meta": {
+      "title": "FluxGuidance"
+    }
+  }
+}

--- a/recipes/comfyui/warmups/fluxschnell.json
+++ b/recipes/comfyui/warmups/fluxschnell.json
@@ -1,0 +1,107 @@
+{
+  "6": {
+    "inputs": {
+      "text": "a bottle with a beautiful rainbow galaxy inside it on top of a wooden table in the middle of a modern kitchen beside a plate of vegetables and mushrooms and a wine glasse that contains a planet earth with a plate with a half eaten apple pie on it",
+      "clip": [
+        "30",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "31",
+        0
+      ],
+      "vae": [
+        "30",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "Flux",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "27": {
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "class_type": "EmptySD3LatentImage",
+    "_meta": {
+      "title": "EmptySD3LatentImage"
+    }
+  },
+  "30": {
+    "inputs": {
+      "ckpt_name": "flux1-schnell-fp8.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "31": {
+    "inputs": {
+      "seed": 1030319533692526,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1,
+      "model": [
+        "30",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "33",
+        0
+      ],
+      "latent_image": [
+        "27",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "33": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "30",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  }
+}

--- a/recipes/comfyui/warmups/sd3.5-medium.json
+++ b/recipes/comfyui/warmups/sd3.5-medium.json
@@ -1,0 +1,187 @@
+{
+  "4": {
+    "inputs": {
+      "ckpt_name": "sd3.5_medium.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "beautiful scenery nature glass bottle landscape, purple galaxy bottle,",
+      "clip": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "294",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "11": {
+    "inputs": {
+      "clip_name1": "clip_g.safetensors",
+      "clip_name2": "clip_l.safetensors",
+      "clip_name3": "t5xxl_fp8_e4m3fn.safetensors"
+    },
+    "class_type": "TripleCLIPLoader",
+    "_meta": {
+      "title": "TripleCLIPLoader"
+    }
+  },
+  "13": {
+    "inputs": {
+      "shift": 3,
+      "model": [
+        "4",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": "ModelSamplingSD3"
+    }
+  },
+  "67": {
+    "inputs": {
+      "conditioning": [
+        "71",
+        0
+      ]
+    },
+    "class_type": "ConditioningZeroOut",
+    "_meta": {
+      "title": "ConditioningZeroOut"
+    }
+  },
+  "68": {
+    "inputs": {
+      "start": 0.1,
+      "end": 1,
+      "conditioning": [
+        "67",
+        0
+      ]
+    },
+    "class_type": "ConditioningSetTimestepRange",
+    "_meta": {
+      "title": "ConditioningSetTimestepRange"
+    }
+  },
+  "69": {
+    "inputs": {
+      "conditioning_1": [
+        "68",
+        0
+      ],
+      "conditioning_2": [
+        "70",
+        0
+      ]
+    },
+    "class_type": "ConditioningCombine",
+    "_meta": {
+      "title": "Conditioning (Combine)"
+    }
+  },
+  "70": {
+    "inputs": {
+      "start": 0,
+      "end": 0.1,
+      "conditioning": [
+        "71",
+        0
+      ]
+    },
+    "class_type": "ConditioningSetTimestepRange",
+    "_meta": {
+      "title": "ConditioningSetTimestepRange"
+    }
+  },
+  "71": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "135": {
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "class_type": "EmptySD3LatentImage",
+    "_meta": {
+      "title": "EmptySD3LatentImage"
+    }
+  },
+  "294": {
+    "inputs": {
+      "seed": 998428620595727,
+      "steps": 20,
+      "cfg": 4.5,
+      "sampler_name": "dpmpp_2m",
+      "scheduler": "sgm_uniform",
+      "denoise": 1,
+      "model": [
+        "13",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "69",
+        0
+      ],
+      "latent_image": [
+        "135",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "301": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/recipes/comfyui/warmups/sdxl-with-refiner.json
+++ b/recipes/comfyui/warmups/sdxl-with-refiner.json
@@ -1,0 +1,178 @@
+{
+  "4": {
+    "inputs": {
+      "ckpt_name": "sd_xl_base_1.0.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint - BASE"
+    }
+  },
+  "5": {
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "Empty Latent Image"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "evening sunset scenery blue sky nature, glass bottle with a galaxy in it",
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "text, watermark",
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "10": {
+    "inputs": {
+      "add_noise": "enable",
+      "noise_seed": 721897303308196,
+      "steps": 25,
+      "cfg": 8,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "start_at_step": 0,
+      "end_at_step": 20,
+      "return_with_leftover_noise": "enable",
+      "model": [
+        "4",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": "KSampler (Advanced) - BASE"
+    }
+  },
+  "11": {
+    "inputs": {
+      "add_noise": "disable",
+      "noise_seed": 0,
+      "steps": 25,
+      "cfg": 8,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "start_at_step": 20,
+      "end_at_step": 10000,
+      "return_with_leftover_noise": "disable",
+      "model": [
+        "12",
+        0
+      ],
+      "positive": [
+        "15",
+        0
+      ],
+      "negative": [
+        "16",
+        0
+      ],
+      "latent_image": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": "KSampler (Advanced) - REFINER"
+    }
+  },
+  "12": {
+    "inputs": {
+      "ckpt_name": "sd_xl_refiner_1.0.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint - REFINER"
+    }
+  },
+  "15": {
+    "inputs": {
+      "text": "evening sunset scenery blue sky nature, glass bottle with a galaxy in it",
+      "clip": [
+        "12",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "16": {
+    "inputs": {
+      "text": "text, watermark",
+      "clip": [
+        "12",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "17": {
+    "inputs": {
+      "samples": [
+        "11",
+        0
+      ],
+      "vae": [
+        "12",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "19": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "17",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}


### PR DESCRIPTION
- updates all comfyui recipes to use latest comfy and latest api, and cuda 12.8 and torch 2.8.0
- adds custom variant for comfyui recipe
- migrates all comfyui recipes to a model manifest / download at runtime system, and stores images in ghcr now instead of dockerhub
- updates the ai-toolkit recipe to use the latest kelpie, which no longer requires specifying the salad project in configuration