### PR TITLE
qwen3.6 35b unsloth model

### DIFF
--- a/recipes/qwen3.6-35b-a3b-llama-cpp/container-group.json
+++ b/recipes/qwen3.6-35b-a3b-llama-cpp/container-group.json
@@ -1,0 +1,91 @@
+{
+  "name": "",
+  "readme": "$replace",
+  "container": {
+    "command": [
+      "sh",
+      "-c",
+      "exec /app/llama-server --temp \"${LLAMA_SERVER_TEMP}\" --top-p \"${LLAMA_SERVER_TOP_P}\" --min-p \"${LLAMA_SERVER_MIN_P}\""
+    ],
+    "environmentVariables": {
+      "LLAMA_ARG_HOST": "::",
+      "LLAMA_ARG_PORT": "8080",
+      "LLAMA_ARG_HF_REPO": "unsloth/Qwen3.6-35B-A3B-GGUF",
+      "LLAMA_ARG_HF_FILE": "Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+      "LLAMA_ARG_N_GPU_LAYERS": "auto",
+      "LLAMA_ARG_CTX_SIZE": "262144",
+      "LLAMA_ARG_N_PARALLEL": "1",
+      "LLAMA_ARG_ALIAS": "qwen3.6-35b-a3b",
+      "LLAMA_ARG_TOP_K": "20",
+      "LLAMA_ARG_JINJA": "on",
+      "LLAMA_ARG_FLASH_ATTN": "on",
+      "LLAMA_ARG_FIT": "on",
+      "LLAMA_SERVER_TEMP": "0.6",
+      "LLAMA_SERVER_TOP_P": "0.95",
+      "LLAMA_SERVER_MIN_P": "0.0"
+    },
+    "image": "ghcr.io/ggml-org/llama.cpp:server-cuda",
+    "imageCaching": true,
+    "resources": {
+      "cpu": 8,
+      "memory": 30720,
+      "gpuClasses": [
+        "ed563892-aacd-40f5-80b7-90c9be6c759b"
+      ],
+      "storageAmount": 107374182400,
+      "shmSize": 2048
+    },
+    "priority": "high"
+  },
+  "autostartPolicy": true,
+  "restartPolicy": "always",
+  "replicas": 1,
+  "startupProbe": {
+    "failureThreshold": 20,
+    "http": {
+      "headers": [],
+      "path": "/health",
+      "port": 8080,
+      "scheme": "http"
+    },
+    "initialDelaySeconds": 300,
+    "periodSeconds": 60,
+    "successThreshold": 1,
+    "timeoutSeconds": 5
+  },
+  "livenessProbe": {
+    "failureThreshold": 3,
+    "http": {
+      "headers": [],
+      "path": "/health",
+      "port": 8080,
+      "scheme": "http"
+    },
+    "initialDelaySeconds": 300,
+    "periodSeconds": 30,
+    "successThreshold": 1,
+    "timeoutSeconds": 5
+  },
+  "readinessProbe": {
+    "failureThreshold": 3,
+    "http": {
+      "headers": [],
+      "path": "/health",
+      "port": 8080,
+      "scheme": "http"
+    },
+    "initialDelaySeconds": 0,
+    "periodSeconds": 3,
+    "successThreshold": 1,
+    "timeoutSeconds": 2
+  },
+  "networking": {
+    "auth": false,
+    "clientRequestTimeout": 100000,
+    "loadBalancer": "least_number_of_connections",
+    "port": 8080,
+    "protocol": "http",
+    "serverResponseTimeout": 100000,
+    "singleConnectionLimit": false
+  }
+}

--- a/recipes/qwen3.6-35b-a3b-llama-cpp/container_template.readme.mdx
+++ b/recipes/qwen3.6-35b-a3b-llama-cpp/container_template.readme.mdx
@@ -1,0 +1,66 @@
+# Qwen3.6-35B-A3B (Unsloth GGUF) with llama.cpp
+
+This deployment runs `Qwen3.6-35B-A3B` with the official `llama.cpp` CUDA server, downloads the public GGUF weights automatically on startup, and exposes an OpenAI-compatible API for tools such as OpenClaw, OpenCode, and other compatible clients.
+
+<Callout variation="note">This recipe is public by default. If you enabled Container Gateway Authentication during deployment, include `Salad-Api-Key` in your requests.</Callout>
+
+## Use With OpenClaw
+
+If you want to connect this deployment to agentic tools, follow this guides:
+
+- [Cline](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-cline-with-saladcloud)
+- [Aider](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-aider-with-saladcloud)
+- [OpenCode](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-opencode-with-saladcloud)
+- [OpenClaw](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-openclaw-with-saladcloud)
+- [Kilo Code](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-kilo-code-with-saladcloud)
+- [Roo Code](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-roo-code-with-saladcloud)
+- [Continue](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-continue-with-saladcloud)
+- [Versel AI](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-vercel-ai-sdk-with-saladcloud)
+- [Goose](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-goose-with-saladcloud)
+- [Hermes](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-hermes-agent-with-saladcloud)
+
+## Access
+
+- <Link url={`https://${props.networking.dns}`}>Open the built-in llama.cpp UI</Link>
+- <Link url={`https://${props.networking.dns}/health`}>Health Check</Link>
+- <Link url={`https://${props.networking.dns}/v1/models`}>List Models</Link>
+
+## Defaults
+
+- Model source: `unsloth/Qwen3.6-35B-A3B-GGUF`
+- Model file: `Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf`
+- Model alias: `qwen3.6-35b-a3b`
+- Context window: `262144` tokens
+- Startup profile: thinking enabled by default
+- Sampling defaults: `temperature 0.6`, `top_p 0.95`, `min_p 0.0`, `top_k 20`
+
+`temperature`, `top_p`, and `min_p` are startup defaults. They can still be overridden per request in your inference payload.
+
+This is a text-only recipe, so automatic multimodal projector lookup is disabled.
+
+Qwen3.6 thinks by default. It does not officially use prompt switches such as `/think` or `/nothink`. To request a direct response in clients that support extra fields, pass `chat_template_kwargs: {"enable_thinking": false}`.
+
+## Curl Example
+
+<CodeBlock language="bash">{`curl https://${props.networking.dns}/v1/chat/completions \\
+    -X POST \\
+    -H 'Content-Type: application/json' \\
+    -d '{
+      "model": "qwen3.6-35b-a3b",
+      "messages": [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Write a short explanation of mixture-of-experts models."}
+      ],
+      "max_tokens": 256
+    }'
+`}</CodeBlock>
+
+If you enabled Container Gateway Authentication during deployment, add `-H 'Salad-Api-Key: ${props.apiKey}'` to your requests.
+
+## Resources
+
+- [Use OpenClaw with a Salad-hosted LLM](https://docs.salad.com/container-engine/how-to-guides/openclaw/openclaw-ollama-salad-hosted-telegram)
+- [Unsloth Qwen3.6 GGUF model card](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF)
+- [llama.cpp Server Documentation](https://github.com/ggml-org/llama.cpp/tree/master/tools/server)
+- [Recipe Source](https://github.com/SaladTechnologies/salad-recipes/tree/master/recipes/qwen3.6-35b-a3b-llama-cpp)
+- <Link url={`https://github.com/SaladTechnologies/salad-recipes/issues/new?title=Qwen3.6-35B-A3B%20llama.cpp&body=Image%3A%20${props.container.image}`}>Report an Issue on GitHub</Link>

--- a/recipes/qwen3.6-35b-a3b-llama-cpp/form.description.mdx
+++ b/recipes/qwen3.6-35b-a3b-llama-cpp/form.description.mdx
@@ -1,0 +1,22 @@
+Run `Qwen3.6-35B-A3B` with `llama.cpp` on a Salad GPU as an OpenAI-compatible API for a wide variety of tools. The best open-source model in its class as of April 2026.
+
+This recipe is designed to be easy for nontechnical users:
+
+- the model is already chosen for you
+- it downloads automatically on startup (might take about 20 minutes to start)
+- you can use it from the built-in web UI, use through its OpenAI-compatible API, or connect tools such as OpenClaw and OpenCode
+
+If you want the simple version: enter a container group name, deploy, and wait for startup to finish.
+
+If you want requests to require a SaladCloud API Key, enable Container Gateway Authentication in the deployment form.
+
+Thinking is enabled by default.  To get direct, non-thinking responses, turn off thinking in this form or pass `chat_template_kwargs: {"enable_thinking": false}` in clients that support extra request fields.
+
+If you disable thinking in the form, the recipe sets Qwen's hard switch and request-level thinking prompts will not override it.
+
+If you want different llama.cpp settings later, you can still change the environment variables in Advanced Configuration after deployment.
+`
+Helpful references:
+
+- [Unsloth Qwen3.6 GGUF model card](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF)
+- [llama.cpp server docs](https://github.com/ggml-org/llama.cpp/tree/master/tools/server)

--- a/recipes/qwen3.6-35b-a3b-llama-cpp/form.json
+++ b/recipes/qwen3.6-35b-a3b-llama-cpp/form.json
@@ -1,0 +1,31 @@
+{
+  "title": "Qwen3.6-35B-A3B (llama.cpp)",
+  "description": "$replace",
+  "type": "object",
+  "required": [
+    "container_group_name",
+    "networking_auth"
+  ],
+  "properties": {
+    "container_group_name": {
+      "title": "Container Group Name",
+      "description": "Required* Must be 2-63 lowercase letters, numbers, or hyphens. Cannot start with a number or start or end with a hyphen.",
+      "type": "string",
+      "maxLength": 63,
+      "minLength": 2,
+      "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$"
+    },
+    "enable_thinking": {
+      "title": "Enable Thinking / Reasoning",
+      "description": "When enabled, Qwen uses its reasoning mode by default. When disabled, the recipe forces non-thinking mode for faster, shorter responses.",
+      "type": "boolean",
+      "default": true
+    },
+    "networking_auth": {
+      "title": "Require Container Gateway Authentication",
+      "description": "When enabled, requests must include a SaladCloud API Key to access the container. When disabled, public (unauthenticated) access is allowed.",
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/recipes/qwen3.6-35b-a3b-llama-cpp/misc.json
+++ b/recipes/qwen3.6-35b-a3b-llama-cpp/misc.json
@@ -1,0 +1,8 @@
+{
+  "ui": {},
+  "documentation_url": "https://docs.salad.com/container-engine/reference/recipes/qwen3.6-35b-a3b-llama-cpp",
+  "short_description": "Serve Qwen3.6-35B-A3B with llama.cpp as an OpenAI-compatible API for OpenClaw, OpenCode, and other tools.",
+  "workload_types": [
+    "LLM"
+  ]
+}

--- a/recipes/qwen3.6-35b-a3b-llama-cpp/patches.json
+++ b/recipes/qwen3.6-35b-a3b-llama-cpp/patches.json
@@ -1,0 +1,46 @@
+[
+  [
+    {
+      "op": "copy",
+      "from": "/input/autostart_policy",
+      "path": "/output/autostartPolicy"
+    },
+    {
+      "op": "copy",
+      "from": "/input/replicas",
+      "path": "/output/replicas"
+    },
+    {
+      "op": "copy",
+      "from": "/input/container_group_name",
+      "path": "/output/name"
+    },
+    {
+      "op": "copy",
+      "from": "/input/networking_auth",
+      "path": "/output/networking/auth"
+    }
+  ],
+  [
+    {
+      "op": "test",
+      "path": "/input/enable_thinking",
+      "value": false
+    },
+    {
+      "op": "add",
+      "path": "/output/container/environmentVariables/LLAMA_CHAT_TEMPLATE_KWARGS",
+      "value": "{\"enable_thinking\":false}"
+    },
+    {
+      "op": "add",
+      "path": "/output/container/environmentVariables/LLAMA_SERVER_TEMP",
+      "value": "0.7"
+    },
+    {
+      "op": "add",
+      "path": "/output/container/environmentVariables/LLAMA_SERVER_TOP_P",
+      "value": "0.80"
+    }
+  ]
+]

--- a/recipes/qwen3.6-35b-a3b-llama-cpp/recipe.json
+++ b/recipes/qwen3.6-35b-a3b-llama-cpp/recipe.json
@@ -1,0 +1,169 @@
+{
+  "container_template": {
+    "name": "",
+    "readme": "# Qwen3.6-35B-A3B (Unsloth GGUF) with llama.cpp\n\nThis deployment runs `Qwen3.6-35B-A3B` with the official `llama.cpp` CUDA server, downloads the public GGUF weights automatically on startup, and exposes an OpenAI-compatible API for tools such as OpenClaw, OpenCode, and other compatible clients.\n\n<Callout variation=\"note\">This recipe is public by default. If you enabled Container Gateway Authentication during deployment, include `Salad-Api-Key` in your requests.</Callout>\n\n## Use With OpenClaw\n\nIf you want to connect this deployment to agentic tools, follow this guides:\n\n- [Cline](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-cline-with-saladcloud)\n- [Aider](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-aider-with-saladcloud)\n- [OpenCode](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-opencode-with-saladcloud)\n- [OpenClaw](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-openclaw-with-saladcloud)\n- [Kilo Code](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-kilo-code-with-saladcloud)\n- [Roo Code](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-roo-code-with-saladcloud)\n- [Continue](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-continue-with-saladcloud)\n- [Versel AI](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-vercel-ai-sdk-with-saladcloud)\n- [Goose](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-goose-with-saladcloud)\n- [Hermes](https://docs.salad.com/container-engine/tutorials/agentic-tools/use-hermes-agent-with-saladcloud)\n\n## Access\n\n- <Link url={`https://${props.networking.dns}`}>Open the built-in llama.cpp UI</Link>\n- <Link url={`https://${props.networking.dns}/health`}>Health Check</Link>\n- <Link url={`https://${props.networking.dns}/v1/models`}>List Models</Link>\n\n## Defaults\n\n- Model source: `unsloth/Qwen3.6-35B-A3B-GGUF`\n- Model file: `Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf`\n- Model alias: `qwen3.6-35b-a3b`\n- Context window: `262144` tokens\n- Startup profile: thinking enabled by default\n- Sampling defaults: `temperature 0.6`, `top_p 0.95`, `min_p 0.0`, `top_k 20`\n\n`temperature`, `top_p`, and `min_p` are startup defaults. They can still be overridden per request in your inference payload.\n\nThis is a text-only recipe, so automatic multimodal projector lookup is disabled.\n\nQwen3.6 thinks by default. It does not officially use prompt switches such as `/think` or `/nothink`. To request a direct response in clients that support extra fields, pass `chat_template_kwargs: {\"enable_thinking\": false}`.\n\n## Curl Example\n\n<CodeBlock language=\"bash\">{`curl https://${props.networking.dns}/v1/chat/completions \\\\\n    -X POST \\\\\n    -H 'Content-Type: application/json' \\\\\n    -d '{\n      \"model\": \"qwen3.6-35b-a3b\",\n      \"messages\": [\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": \"Write a short explanation of mixture-of-experts models.\"}\n      ],\n      \"max_tokens\": 256\n    }'\n`}</CodeBlock>\n\nIf you enabled Container Gateway Authentication during deployment, add `-H 'Salad-Api-Key: ${props.apiKey}'` to your requests.\n\n## Resources\n\n- [Use OpenClaw with a Salad-hosted LLM](https://docs.salad.com/container-engine/how-to-guides/openclaw/openclaw-ollama-salad-hosted-telegram)\n- [Unsloth Qwen3.6 GGUF model card](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF)\n- [llama.cpp Server Documentation](https://github.com/ggml-org/llama.cpp/tree/master/tools/server)\n- [Recipe Source](https://github.com/SaladTechnologies/salad-recipes/tree/master/recipes/qwen3.6-35b-a3b-llama-cpp)\n- <Link url={`https://github.com/SaladTechnologies/salad-recipes/issues/new?title=Qwen3.6-35B-A3B%20llama.cpp&body=Image%3A%20${props.container.image}`}>Report an Issue on GitHub</Link>\n",
+    "container": {
+      "command": [
+        "sh",
+        "-c",
+        "exec /app/llama-server --temp \"${LLAMA_SERVER_TEMP}\" --top-p \"${LLAMA_SERVER_TOP_P}\" --min-p \"${LLAMA_SERVER_MIN_P}\""
+      ],
+      "environmentVariables": {
+        "LLAMA_ARG_HOST": "::",
+        "LLAMA_ARG_PORT": "8080",
+        "LLAMA_ARG_HF_REPO": "unsloth/Qwen3.6-35B-A3B-GGUF",
+        "LLAMA_ARG_HF_FILE": "Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+        "LLAMA_ARG_N_GPU_LAYERS": "auto",
+        "LLAMA_ARG_CTX_SIZE": "262144",
+        "LLAMA_ARG_N_PARALLEL": "1",
+        "LLAMA_ARG_ALIAS": "qwen3.6-35b-a3b",
+        "LLAMA_ARG_TOP_K": "20",
+        "LLAMA_ARG_JINJA": "on",
+        "LLAMA_ARG_FLASH_ATTN": "on",
+        "LLAMA_ARG_FIT": "on",
+        "LLAMA_SERVER_TEMP": "0.6",
+        "LLAMA_SERVER_TOP_P": "0.95",
+        "LLAMA_SERVER_MIN_P": "0.0"
+      },
+      "image": "ghcr.io/ggml-org/llama.cpp:server-cuda",
+      "imageCaching": true,
+      "resources": {
+        "cpu": 8,
+        "memory": 30720,
+        "gpuClasses": ["ed563892-aacd-40f5-80b7-90c9be6c759b"],
+        "storageAmount": 107374182400,
+        "shmSize": 2048
+      },
+      "priority": "high"
+    },
+    "autostartPolicy": true,
+    "restartPolicy": "always",
+    "replicas": 1,
+    "startupProbe": {
+      "failureThreshold": 20,
+      "http": {
+        "headers": [],
+        "path": "/health",
+        "port": 8080,
+        "scheme": "http"
+      },
+      "initialDelaySeconds": 300,
+      "periodSeconds": 60,
+      "successThreshold": 1,
+      "timeoutSeconds": 5
+    },
+    "livenessProbe": {
+      "failureThreshold": 3,
+      "http": {
+        "headers": [],
+        "path": "/health",
+        "port": 8080,
+        "scheme": "http"
+      },
+      "initialDelaySeconds": 300,
+      "periodSeconds": 30,
+      "successThreshold": 1,
+      "timeoutSeconds": 5
+    },
+    "readinessProbe": {
+      "failureThreshold": 3,
+      "http": {
+        "headers": [],
+        "path": "/health",
+        "port": 8080,
+        "scheme": "http"
+      },
+      "initialDelaySeconds": 0,
+      "periodSeconds": 3,
+      "successThreshold": 1,
+      "timeoutSeconds": 2
+    },
+    "networking": {
+      "auth": false,
+      "clientRequestTimeout": 100000,
+      "loadBalancer": "least_number_of_connections",
+      "port": 8080,
+      "protocol": "http",
+      "serverResponseTimeout": 100000,
+      "singleConnectionLimit": false
+    }
+  },
+  "form": {
+    "title": "Qwen3.6-35B-A3B (llama.cpp)",
+    "description": "Run `Qwen3.6-35B-A3B` with `llama.cpp` on a Salad GPU as an OpenAI-compatible API for a wide variety of tools. The best open-source model in its class as of April 2026.\n\nThis recipe is designed to be easy for nontechnical users:\n\n- the model is already chosen for you\n- it downloads automatically on startup (might take about 20 minutes to start)\n- you can use it from the built-in web UI, use through its OpenAI-compatible API, or connect tools such as OpenClaw and OpenCode\n\nIf you want the simple version: enter a container group name, deploy, and wait for startup to finish.\n\nIf you want requests to require a SaladCloud API Key, enable Container Gateway Authentication in the deployment form.\n\nThinking is enabled by default.  To get direct, non-thinking responses, turn off thinking in this form or pass `chat_template_kwargs: {\"enable_thinking\": false}` in clients that support extra request fields.\n\nIf you disable thinking in the form, the recipe sets Qwen's hard switch and request-level thinking prompts will not override it.\n\nIf you want different llama.cpp settings later, you can still change the environment variables in Advanced Configuration after deployment.\n`\nHelpful references:\n\n- [Unsloth Qwen3.6 GGUF model card](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF)\n- [llama.cpp server docs](https://github.com/ggml-org/llama.cpp/tree/master/tools/server)\n",
+    "type": "object",
+    "required": ["container_group_name", "networking_auth"],
+    "properties": {
+      "container_group_name": {
+        "title": "Container Group Name",
+        "description": "Required* Must be 2-63 lowercase letters, numbers, or hyphens. Cannot start with a number or start or end with a hyphen.",
+        "type": "string",
+        "maxLength": 63,
+        "minLength": 2,
+        "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$"
+      },
+      "enable_thinking": {
+        "title": "Enable Thinking / Reasoning",
+        "description": "When enabled, Qwen uses its reasoning mode by default. When disabled, the recipe forces non-thinking mode for faster, shorter responses.",
+        "type": "boolean",
+        "default": true
+      },
+      "networking_auth": {
+        "title": "Require Container Gateway Authentication",
+        "description": "When enabled, requests must include a SaladCloud API Key to access the container. When disabled, public (unauthenticated) access is allowed.",
+        "type": "boolean",
+        "default": false
+      }
+    }
+  },
+  "patches": [
+    [
+      {
+        "op": "copy",
+        "from": "/input/autostart_policy",
+        "path": "/output/autostartPolicy"
+      },
+      {
+        "op": "copy",
+        "from": "/input/replicas",
+        "path": "/output/replicas"
+      },
+      {
+        "op": "copy",
+        "from": "/input/container_group_name",
+        "path": "/output/name"
+      },
+      {
+        "op": "copy",
+        "from": "/input/networking_auth",
+        "path": "/output/networking/auth"
+      }
+    ],
+    [
+      {
+        "op": "test",
+        "path": "/input/enable_thinking",
+        "value": false
+      },
+      {
+        "op": "add",
+        "path": "/output/container/environmentVariables/LLAMA_CHAT_TEMPLATE_KWARGS",
+        "value": "{\"enable_thinking\":false}"
+      },
+      {
+        "op": "add",
+        "path": "/output/container/environmentVariables/LLAMA_SERVER_TEMP",
+        "value": "0.7"
+      },
+      {
+        "op": "add",
+        "path": "/output/container/environmentVariables/LLAMA_SERVER_TOP_P",
+        "value": "0.80"
+      }
+    ]
+  ],
+  "ui": {},
+  "documentation_url": "https://docs.salad.com/container-engine/reference/recipes/qwen3.6-35b-a3b-llama-cpp",
+  "short_description": "Serve Qwen3.6-35B-A3B with llama.cpp as an OpenAI-compatible API for OpenClaw, OpenCode, and other tools.",
+  "workload_types": ["LLM"]
+}


### PR DESCRIPTION
This pull request introduces a new SaladCloud recipe for deploying the Qwen3.6-35B-A3B language model using llama.cpp, optimized for ease of use and compatibility with OpenAI-style APIs and agentic tools. The recipe includes all necessary configuration, documentation, and user interface files to enable both technical and non-technical users to deploy, customize, and access the model with minimal effort.

The most important changes are:

**Recipe Definition & Container Configuration**
- Added a complete `recipe.json` and `container-group.json` for the Qwen3.6-35B-A3B model, specifying the llama.cpp CUDA server image, environment variables for model selection and inference defaults, resource requirements (GPU, CPU, memory), health checks, and networking setup for OpenAI-compatible API access. [[1]](diffhunk://#diff-b734220a3c972fc919d99b104d4e7fe6c2a0c9c2b5bb9366b185eec4b93b3198R1-R169) [[2]](diffhunk://#diff-3a96cba436742eb21881e3cc0fc399c7ffcaaeedb9df766e8f2bd3e270909861R1-R91)

**User Interface & Documentation**
- Added a detailed user-facing README (`container_template.readme.mdx`) and deployment form description (`form.description.mdx`) with instructions, usage examples, and references to compatible tools and model documentation. [[1]](diffhunk://#diff-4568a975528c79c0b20a3215133f7bce4e7fa1b331f540d7ae588a989c0d89ebR1-R66) [[2]](diffhunk://#diff-f8c6fc5556f2a7fd04863613b88688625b89e7f0ddb4eb649ee56542a3a5af81R1-R22)

**Deployment Form & Customization**
- Added a JSON schema for the deployment form (`form.json`) allowing users to set the container group name, enable/disable "thinking" mode, and require API authentication.

**Dynamic Configuration via Patches**
- Added `patches.json` to map user form selections to container configuration, including toggling thinking mode and adjusting inference parameters based on user preferences.

**Recipe Metadata**
- Added metadata (`misc.json`) for UI integration, documentation links, and workload type classification.