### PR TITLE
Add Unsloth Studio recipe (no-code LLM fine-tuning web UI)

### DIFF
--- a/recipes/unsloth-studio/Dockerfile
+++ b/recipes/unsloth-studio/Dockerfile
@@ -1,72 +1,90 @@
 # ---------------------------------------------------------------------------
 # Unsloth Studio - SaladCloud Recipe
 # ---------------------------------------------------------------------------
-# Image auto-suffisante : Unsloth Studio (+ PyTorch/CUDA) est installe AU BUILD.
-# Au demarrage sur SaladCloud, le conteneur lance Studio et publie une URL.
-# Comme SaladCloud relance toujours cette meme image, plus besoin de reinstaller
-# quoi que ce soit apres une reallocation.
+# Self-contained image: Unsloth Studio (+ PyTorch/CUDA) is installed AT BUILD
+# time. On SaladCloud the container starts Studio and publishes a URL. Since
+# SaladCloud always restarts this same image, nothing needs to be reinstalled
+# after a node reallocation.
 #
-# GPU requis : NVIDIA Blackwell/Ada (ex. RTX 5090/4090). Les wheels PyTorch
-# embarquent CUDA, on part donc d'un simple Ubuntu 24.04 ; SaladCloud fournit le
-# driver NVIDIA a l'execution.
+# GPU required: NVIDIA Blackwell/Ada (e.g. RTX 5090/4090). The PyTorch wheels
+# bundle CUDA, so a plain Ubuntu 24.04 base is enough; SaladCloud provides the
+# NVIDIA driver at runtime.
 # ---------------------------------------------------------------------------
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Dependances systeme (cmake + libcurl : moteur GGUF d'Unsloth ; expect : saisie
-# non-interactive du mot de passe ; tmux/git : confort + install).
+# System dependencies (cmake + libcurl: Unsloth's GGUF engine; expect:
+# non-interactive password entry; tmux/git: convenience + install).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl git ca-certificates build-essential cmake libcurl4-openssl-dev \
         python3 python3-venv python3-pip expect tmux \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Installation d'Unsloth Studio au build (bake torch CUDA + unsloth) ------
-# PROBLEME : le build tourne sur un runner sans GPU -> install.sh detecte "pas de
-# GPU" et installe PyTorch **CPU** (torch.cuda indisponible au runtime = erreur
-# "no GPU backend available"). SOLUTION : on simule un GPU via un faux nvidia-smi
-# le temps de l'install, pour qu'install.sh prenne la stack **CUDA** (torch cu130
-# + torchao GPU). Le vrai driver NVIDIA est fourni par SaladCloud a l'execution.
+# --- Install Unsloth Studio at build time (bake CUDA torch + unsloth) --------
+# PROBLEM: the build runs on a GPU-less runner -> install.sh detects "no GPU"
+# and installs **CPU** PyTorch (torch.cuda unavailable at runtime = "no GPU
+# backend available" error). SOLUTION: fake a GPU with a stub nvidia-smi during
+# the install so install.sh picks the **CUDA** stack (torch cu130 + GPU
+# torchao). The real NVIDIA driver is provided by SaladCloud at runtime.
+# CAUTION: install.sh picks the PyTorch index (cu126/cu128/cu130) by reading
+# the "CUDA Version: X.Y" line of nvidia-smi output; without it, it falls back
+# to **cu126**, whose wheels DO NOT have Blackwell sm_120 kernels -> on an
+# RTX 5090 model loading fails ("no kernel image is available for execution on
+# the device"). The stub nvidia-smi MUST therefore report "CUDA Version: 13.0"
+# to get cu130 (sm_89 4090 AND sm_120 5090).
 ENV UNSLOTH_SKIP_AUTOSTART=1
-RUN printf '#!/bin/sh\necho "GPU 0: NVIDIA GeForce RTX 4090 (UUID: GPU-00000000-0000-0000-0000-000000000000)"\nexit 0\n' \
+RUN printf '#!/bin/sh\necho "GPU 0: NVIDIA GeForce RTX 4090 (UUID: GPU-00000000-0000-0000-0000-000000000000)"\necho "CUDA Version: 13.0"\nexit 0\n' \
         > /usr/local/bin/nvidia-smi \
     && chmod +x /usr/local/bin/nvidia-smi \
     && curl -fsSL https://unsloth.ai/install.sh | sh \
     && rm -f /usr/local/bin/nvidia-smi
 
-# Ceinture + bretelles : si torch est malgre tout en CPU, forcer la variante CUDA
-# (meme version) depuis l'index cu130. Le driver SaladCloud est CUDA 13.x.
+# Belt and suspenders: if torch is CPU-only OR CUDA < 12.8 (no Blackwell sm_120
+# kernels -> crash at model load on RTX 5090), force the cu130 variant (same
+# version). The SaladCloud driver is CUDA 13.x.
 RUN set -e; \
     PIP=/root/.unsloth/studio/unsloth_studio/bin/pip; \
     PY=/root/.unsloth/studio/unsloth_studio/bin/python; \
-    if $PY -c "import torch,sys; sys.exit(0 if torch.version.cuda else 1)"; then \
+    if $PY -c "import torch,sys; v=torch.version.cuda; sys.exit(0 if v and tuple(map(int,v.split('.')[:2]))>=(12,8) else 1)"; then \
         echo "torch CUDA OK: $($PY -c 'import torch;print(torch.__version__)')"; \
     else \
         TV=$($PY -c "import torch;print(torch.__version__.split('+')[0])"); \
-        echo "torch CPU detecte ($TV) -> reinstall cu130"; \
+        echo "torch is CPU-only or CUDA < 12.8 ($TV) -> reinstalling cu130"; \
         $PIP install --no-cache-dir --force-reinstall "torch==$TV" \
             --index-url https://download.pytorch.org/whl/cu130; \
-    fi
+    fi; \
+    $PY -c "import torch; v=torch.version.cuda; assert v and tuple(map(int,v.split('.')[:2]))>=(12,8), f'torch {torch.__version__} lacks Blackwell sm_120 support'"
 
-# --- Correctif inference : retirer flash_attn -> Unsloth bascule sur sdpa ----
-# Sinon crash sur certains modeles (Nemotron, Gemma-3...) :
+# --- Inference fix: remove flash_attn -> Unsloth falls back to sdpa ----------
+# Otherwise some models crash (Nemotron, Gemma-3...):
 #   "static cache is not compatible with attn_implementation==flash_attention_2"
 RUN /root/.unsloth/studio/unsloth_studio/bin/pip uninstall -y flash_attn flash-attn || true
 
 ENV PATH="/root/.unsloth/studio/unsloth_studio/bin:${PATH}"
 
-# Cache Hugging Face sur un chemin stable (montable en volume persistant Salad)
+# Hugging Face cache on a stable path (mountable as a Salad persistent volume)
 ENV HF_HOME=/root/.cache/huggingface
 
-# Defauts adaptes a SaladCloud Container Gateway (URL stable, pas de Cloudflare) :
-# Studio ecoute sur 0.0.0.0:8080, le Gateway expose ce port publiquement.
+# Defaults suited to the SaladCloud Container Gateway (stable URL, no
+# Cloudflare): Studio listens on '::' (dual-stack, port 8080) and the Gateway
+# exposes that port publicly.
 ENV EXPOSE_MODE=gateway
 ENV STUDIO_PORT=8080
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Port web de Studio (utilise si tu exposes via SaladCloud Container Gateway)
+# Studio web port (used when exposing via the SaladCloud Container Gateway)
 EXPOSE 8080
 
-ENTRYPOINT ["/entrypoint.sh"]
+# tini as PID 1: Studio must NEVER run as PID 1. Its child-spawn preexec hook
+# (studio/backend/utils/process_lifetime.py) kills every spawned llama-server
+# when getppid()==1 ("parent already died") -> with Studio as PID 1 every model
+# load fails instantly ("llama-server failed to start", exit 1, empty log).
+# Behind tini, Studio gets a pid > 1 and the guard stays inert.
+# (Dedicated layer at the end of the build so it does not invalidate the cache
+# of the big torch/unsloth install layers above.)
+RUN apt-get update && apt-get install -y --no-install-recommends tini \
+    && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]

--- a/recipes/unsloth-studio/Dockerfile
+++ b/recipes/unsloth-studio/Dockerfile
@@ -1,0 +1,72 @@
+# ---------------------------------------------------------------------------
+# Unsloth Studio - SaladCloud Recipe
+# ---------------------------------------------------------------------------
+# Image auto-suffisante : Unsloth Studio (+ PyTorch/CUDA) est installe AU BUILD.
+# Au demarrage sur SaladCloud, le conteneur lance Studio et publie une URL.
+# Comme SaladCloud relance toujours cette meme image, plus besoin de reinstaller
+# quoi que ce soit apres une reallocation.
+#
+# GPU requis : NVIDIA Blackwell/Ada (ex. RTX 5090/4090). Les wheels PyTorch
+# embarquent CUDA, on part donc d'un simple Ubuntu 24.04 ; SaladCloud fournit le
+# driver NVIDIA a l'execution.
+# ---------------------------------------------------------------------------
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Dependances systeme (cmake + libcurl : moteur GGUF d'Unsloth ; expect : saisie
+# non-interactive du mot de passe ; tmux/git : confort + install).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl git ca-certificates build-essential cmake libcurl4-openssl-dev \
+        python3 python3-venv python3-pip expect tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Installation d'Unsloth Studio au build (bake torch CUDA + unsloth) ------
+# PROBLEME : le build tourne sur un runner sans GPU -> install.sh detecte "pas de
+# GPU" et installe PyTorch **CPU** (torch.cuda indisponible au runtime = erreur
+# "no GPU backend available"). SOLUTION : on simule un GPU via un faux nvidia-smi
+# le temps de l'install, pour qu'install.sh prenne la stack **CUDA** (torch cu130
+# + torchao GPU). Le vrai driver NVIDIA est fourni par SaladCloud a l'execution.
+ENV UNSLOTH_SKIP_AUTOSTART=1
+RUN printf '#!/bin/sh\necho "GPU 0: NVIDIA GeForce RTX 4090 (UUID: GPU-00000000-0000-0000-0000-000000000000)"\nexit 0\n' \
+        > /usr/local/bin/nvidia-smi \
+    && chmod +x /usr/local/bin/nvidia-smi \
+    && curl -fsSL https://unsloth.ai/install.sh | sh \
+    && rm -f /usr/local/bin/nvidia-smi
+
+# Ceinture + bretelles : si torch est malgre tout en CPU, forcer la variante CUDA
+# (meme version) depuis l'index cu130. Le driver SaladCloud est CUDA 13.x.
+RUN set -e; \
+    PIP=/root/.unsloth/studio/unsloth_studio/bin/pip; \
+    PY=/root/.unsloth/studio/unsloth_studio/bin/python; \
+    if $PY -c "import torch,sys; sys.exit(0 if torch.version.cuda else 1)"; then \
+        echo "torch CUDA OK: $($PY -c 'import torch;print(torch.__version__)')"; \
+    else \
+        TV=$($PY -c "import torch;print(torch.__version__.split('+')[0])"); \
+        echo "torch CPU detecte ($TV) -> reinstall cu130"; \
+        $PIP install --no-cache-dir --force-reinstall "torch==$TV" \
+            --index-url https://download.pytorch.org/whl/cu130; \
+    fi
+
+# --- Correctif inference : retirer flash_attn -> Unsloth bascule sur sdpa ----
+# Sinon crash sur certains modeles (Nemotron, Gemma-3...) :
+#   "static cache is not compatible with attn_implementation==flash_attention_2"
+RUN /root/.unsloth/studio/unsloth_studio/bin/pip uninstall -y flash_attn flash-attn || true
+
+ENV PATH="/root/.unsloth/studio/unsloth_studio/bin:${PATH}"
+
+# Cache Hugging Face sur un chemin stable (montable en volume persistant Salad)
+ENV HF_HOME=/root/.cache/huggingface
+
+# Defauts adaptes a SaladCloud Container Gateway (URL stable, pas de Cloudflare) :
+# Studio ecoute sur 0.0.0.0:8080, le Gateway expose ce port publiquement.
+ENV EXPOSE_MODE=gateway
+ENV STUDIO_PORT=8080
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Port web de Studio (utilise si tu exposes via SaladCloud Container Gateway)
+EXPOSE 8080
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/recipes/unsloth-studio/container-group.json
+++ b/recipes/unsloth-studio/container-group.json
@@ -13,7 +13,7 @@
       "cpu": 8,
       "memory": 24576,
       "gpuClasses": [
-        "ed563892-aacd-40f5-80b7-90c9be6c759b"
+        "851399fb-7329-4195-a042-d6514b28cf33"
       ],
       "storageAmount": 107374182400,
       "shmSize": 4096

--- a/recipes/unsloth-studio/container-group.json
+++ b/recipes/unsloth-studio/container-group.json
@@ -5,7 +5,8 @@
     "command": [],
     "environmentVariables": {
       "EXPOSE_MODE": "gateway",
-      "STUDIO_PORT": "8080"
+      "STUDIO_PORT": "8080",
+      "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin"
     },
     "image": "volkobfq/unsloth-studio@sha256:23d88a29daf2e6acb05aa6872c1a71996ffe9a24b761624b507418f514de7750",
     "imageCaching": false,

--- a/recipes/unsloth-studio/container-group.json
+++ b/recipes/unsloth-studio/container-group.json
@@ -8,7 +8,7 @@
       "STUDIO_PORT": "8080",
       "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_runtime/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cublas/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_nvrtc/lib"
     },
-    "image": "volkobfq/unsloth-studio@sha256:c6b8ac1b0a01301ef9ec2500cf00c4675089eaa289d0ab2af37d35a64c6d614c",
+    "image": "volkobfq/unsloth-studio@sha256:4630bc2d37518775af741c34f53183c729709225f34cbb9dc81d1fab52092c7f",
     "imageCaching": false,
     "resources": {
       "cpu": 8,

--- a/recipes/unsloth-studio/container-group.json
+++ b/recipes/unsloth-studio/container-group.json
@@ -6,9 +6,9 @@
     "environmentVariables": {
       "EXPOSE_MODE": "gateway",
       "STUDIO_PORT": "8080",
-      "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin"
+      "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_runtime/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cublas/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_nvrtc/lib"
     },
-    "image": "volkobfq/unsloth-studio@sha256:23d88a29daf2e6acb05aa6872c1a71996ffe9a24b761624b507418f514de7750",
+    "image": "volkobfq/unsloth-studio@sha256:c6b8ac1b0a01301ef9ec2500cf00c4675089eaa289d0ab2af37d35a64c6d614c",
     "imageCaching": false,
     "resources": {
       "cpu": 8,

--- a/recipes/unsloth-studio/container-group.json
+++ b/recipes/unsloth-studio/container-group.json
@@ -8,7 +8,7 @@
       "STUDIO_PORT": "8080",
       "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_runtime/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cublas/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_nvrtc/lib"
     },
-    "image": "volkobfq/unsloth-studio@sha256:4630bc2d37518775af741c34f53183c729709225f34cbb9dc81d1fab52092c7f",
+    "image": "volkobfq/unsloth-studio@sha256:da6347e54d71fc6b1e6475363b08efdfd6351ec74201fb1930f54ced0e264df6",
     "imageCaching": false,
     "resources": {
       "cpu": 8,

--- a/recipes/unsloth-studio/container-group.json
+++ b/recipes/unsloth-studio/container-group.json
@@ -1,0 +1,48 @@
+{
+  "name": "",
+  "readme": "$replace",
+  "container": {
+    "command": [],
+    "environmentVariables": {
+      "EXPOSE_MODE": "gateway",
+      "STUDIO_PORT": "8080"
+    },
+    "image": "volkobfq/unsloth-studio@sha256:23d88a29daf2e6acb05aa6872c1a71996ffe9a24b761624b507418f514de7750",
+    "imageCaching": false,
+    "resources": {
+      "cpu": 8,
+      "memory": 24576,
+      "gpuClasses": [
+        "ed563892-aacd-40f5-80b7-90c9be6c759b"
+      ],
+      "storageAmount": 107374182400,
+      "shmSize": 4096
+    },
+    "priority": "high"
+  },
+  "autostartPolicy": true,
+  "restartPolicy": "always",
+  "replicas": 1,
+  "networking": {
+    "auth": false,
+    "clientRequestTimeout": 100000,
+    "loadBalancer": "least_number_of_connections",
+    "port": 8080,
+    "protocol": "http",
+    "serverResponseTimeout": 100000,
+    "singleConnectionLimit": false
+  },
+  "readinessProbe": {
+    "failureThreshold": 20,
+    "http": {
+      "headers": [],
+      "path": "/",
+      "port": 8080,
+      "scheme": "http"
+    },
+    "initialDelaySeconds": 30,
+    "periodSeconds": 15,
+    "successThreshold": 1,
+    "timeoutSeconds": 5
+  }
+}

--- a/recipes/unsloth-studio/container_template.readme.mdx
+++ b/recipes/unsloth-studio/container_template.readme.mdx
@@ -1,0 +1,40 @@
+## Your Unsloth Studio is deploying 🦥
+
+It can take a few minutes for a node to be allocated, pull the image and start.
+
+### 1. Open the Studio
+
+Once the container group is **Running**, open the **Access Domain Name** shown in
+the SaladCloud Portal (Container Gateway URL). That's your Studio.
+
+### 2. Authentication
+
+- **Container Gateway auth** (if you enabled it): requests need a SaladCloud API
+  key. The Portal preview handles this for you; for direct browser access, keep
+  it disabled or use an authenticated client.
+- **Studio password**: log in with the **admin password** you set in the form.
+
+### 3. Fine-tune & run
+
+Use the **Entraîner / Train** tab to fine-tune a model, and the **Chat** tab to
+test the base vs. fine-tuned model side by side.
+
+### ⚠️ Persist your work
+
+SaladCloud nodes are ephemeral — if a node is reallocated, anything written only
+to local disk is lost. To keep your trained models:
+
+- Provide a **Hugging Face token** and **push/export** your model to the Hub from
+  the Studio **Export** tab, **or**
+- Download your artifacts before stopping the group.
+
+The image itself (Unsloth + PyTorch) is baked in, so a recycled node comes back
+ready without any reinstall.
+
+### Notes
+
+- The image already removes `flash_attn` so inference uses `sdpa`, avoiding the
+  `static cache is not compatible with flash_attention_2` error on Nemotron /
+  Gemma-3 style models.
+- Default GPU class is high-VRAM. Adjust CPU / RAM / GPU class in the form or the
+  container group settings to fit the models you train.

--- a/recipes/unsloth-studio/entrypoint.sh
+++ b/recipes/unsloth-studio/entrypoint.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# Entrypoint SaladCloud pour Unsloth Studio
+# SaladCloud entrypoint for Unsloth Studio
 # ---------------------------------------------------------------------------
-# Variables d'environnement (a definir dans le container group SaladCloud) :
-#   UNSLOTH_PASSWORD  mot de passe admin du Studio          (defaut: change-me-please)
-#   STUDIO_PORT       port web interne                       (defaut: 8080)
-#   EXPOSE_MODE       "cloudflare" -> URL publique *.trycloudflare.com (dans les logs)
-#                     "gateway"    -> ecoute sur '::' (IPv6/dual-stack), a exposer
-#                                     via SaladCloud Container Gateway
-#                     (defaut: cloudflare)
-#   HF_TOKEN          (optionnel) login Hugging Face -> push/pull de modeles
+# Environment variables (set on the SaladCloud container group):
+#   UNSLOTH_PASSWORD  Studio admin password                  (default: change-me-please)
+#   STUDIO_PORT       internal web port                      (default: 8080)
+#   EXPOSE_MODE       "cloudflare" -> public *.trycloudflare.com URL (in the logs)
+#                     "gateway"    -> listen on '::' (IPv6/dual-stack), exposed
+#                                     via the SaladCloud Container Gateway
+#                     (default: cloudflare)
+#   HF_TOKEN          (optional) Hugging Face login -> push/pull models
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
@@ -18,32 +18,33 @@ PORT="${STUDIO_PORT:-8080}"
 MODE="${EXPOSE_MODE:-cloudflare}"
 UNS="/root/.unsloth/studio/unsloth_studio/bin/unsloth"
 
-# Definition NON-INTERACTIVE du mot de passe admin (evite le prompt "New
-# password:" qui bloque un conteneur headless). Studio lit cette variable au
-# 1er demarrage ; ensuite l'utilisateur peut le changer dans l'UI.
+# Set the admin password NON-INTERACTIVELY (avoids the "New password:" prompt
+# that would block a headless container). Studio reads this variable on first
+# start; the user can change it later in the UI.
 export UNSLOTH_STUDIO_PASSWORD="${PASS}"
 
-# Moteur GGUF (llama.cpp) sur GPU :
-#  - llama-server n'a pas de rpath vers ses propres libs (libllama-server-impl.so,
-#    libggml*.so) -> il faut son dossier de libs sur le path.
-#  - la build CUDA (libggml-cuda.so) a besoin des libs runtime CUDA de torch
-#    (libcudart, libcublas, libnvrtc) -> on ajoute aussi ces dossiers.
+# GGUF engine (llama.cpp) on GPU:
+#  - llama-server has no rpath to its own libs (libllama-server-impl.so,
+#    libggml*.so) -> its lib directory must be on the path.
+#  - the CUDA build (libggml-cuda.so) needs torch's CUDA runtime libs
+#    (libcudart, libcublas, libnvrtc) -> add those directories too.
 _NVLIB="/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia"
 export LD_LIBRARY_PATH="/root/.unsloth/llama.cpp/build/bin:${_NVLIB}/cuda_runtime/lib:${_NVLIB}/cublas/lib:${_NVLIB}/cuda_nvrtc/lib:${LD_LIBRARY_PATH:-}"
 
-# GGUF accelere GPU : l'image embarque un llama.cpp CPU (build sans GPU au CI).
-# Au 1er boot (GPU reel present -> resolution correcte, download GitHub OK depuis
-# Salad) on installe la build CUDA prebuilt d'Unsloth.
-# IMPORTANT : l'installeur, lance sur un dossier existant, le SUPPRIME parfois
-# sans reinstaller (1er passage) -> on installe dans un dossier TEMPORAIRE, et on
-# ne remplace le llama.cpp CPU (qui sert le GGUF en attendant) que si la build
-# CUDA est validee (swap atomique). Aucune fenetre "runtime not installed".
+# GPU-accelerated GGUF: the image ships a CPU-only llama.cpp (built without a
+# GPU in CI). On first boot (real GPU present -> correct detection, GitHub
+# download works from Salad) install Unsloth's prebuilt CUDA build.
+# IMPORTANT: when pointed at an existing directory the installer sometimes
+# DELETES it without reinstalling (first pass) -> install into a TEMPORARY
+# directory and only replace the CPU llama.cpp (which keeps serving GGUF in the
+# meantime) once the CUDA build is validated (atomic swap). No "runtime not
+# installed" window.
 _STUDIO_PY="/root/.unsloth/studio/unsloth_studio/bin/python"
 _LC_INSTALLER="/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/studio/install_llama_prebuilt.py"
 _LC_DIR="/root/.unsloth/llama.cpp"
 _LC_TMP="/root/.unsloth/llama.cpp.cuda"
 if [ -x "${_STUDIO_PY}" ] && [ -f "${_LC_INSTALLER}" ]; then
-  echo "[entrypoint] Installation llama.cpp CUDA (GGUF GPU) en tache de fond..."
+  echo "[entrypoint] Installing llama.cpp CUDA (GPU GGUF) in the background..."
   (
     ok=0
     for attempt in 1 2 3; do
@@ -52,45 +53,45 @@ if [ -x "${_STUDIO_PY}" ] && [ -f "${_LC_INSTALLER}" ]; then
            && [ -f "${_LC_TMP}/build/bin/libggml-cuda.so" ]; then
         ok=1; break
       fi
-      echo "[entrypoint] tentative ${attempt} echouee, retry..."; sleep 5
+      echo "[entrypoint] attempt ${attempt} failed, retrying..."; sleep 5
     done
     if [ "${ok}" = "1" ]; then
       rm -rf "${_LC_DIR}" && mv "${_LC_TMP}" "${_LC_DIR}"
       ldconfig 2>/dev/null || true
-      echo "[entrypoint] llama.cpp CUDA pret (GGUF accelere GPU)."
+      echo "[entrypoint] llama.cpp CUDA ready (GPU-accelerated GGUF)."
     else
       rm -rf "${_LC_TMP}"
-      echo "[entrypoint] install llama.cpp CUDA echouee -> GGUF reste en CPU."
+      echo "[entrypoint] llama.cpp CUDA install failed -> GGUF stays on CPU."
     fi
   ) > /root/llama_cuda_install.log 2>&1 &
 fi
 
-# Login HF optionnel (permet de sauvegarder tes LoRA hors de la box)
+# Optional HF login (lets you save your LoRAs off the box)
 if [ -n "${HF_TOKEN:-}" ]; then
-  echo "[entrypoint] Login Hugging Face..."
+  echo "[entrypoint] Hugging Face login..."
   /root/.unsloth/studio/unsloth_studio/bin/huggingface-cli login --token "${HF_TOKEN}" || \
-    echo "[entrypoint] (login HF ignore)"
+    echo "[entrypoint] (HF login skipped)"
 fi
 
-# Diagnostic GPU (le "no GPU backend available" vient-il du conteneur ou de Studio ?)
+# GPU diagnostic (is "no GPU backend available" coming from the container or from Studio?)
 echo "[entrypoint] GPU check (nvidia-smi):"
-nvidia-smi -L 2>&1 | head -2 || echo "[entrypoint]   nvidia-smi indisponible (pas de GPU expose au conteneur ?)"
+nvidia-smi -L 2>&1 | head -2 || echo "[entrypoint]   nvidia-smi unavailable (no GPU exposed to the container?)"
 
-# Options reseau selon le mode d'exposition
+# Network options depending on the exposure mode
 if [ "${MODE}" = "gateway" ]; then
-  # --secure (tunnel Cloudflare) echoue depuis un conteneur SaladCloud (sortie
-  # cloudflared bloquee) -> on utilise --no-secure.
-  # IMPORTANT: le SaladCloud Container Gateway route en IPv6 -> il faut ecouter
-  # sur '::' (dual-stack), sinon 503. (0.0.0.0 = IPv4 seul = injoignable.)
+  # --secure (Cloudflare tunnel) fails from a SaladCloud container (cloudflared
+  # egress blocked) -> use --no-secure.
+  # IMPORTANT: the SaladCloud Container Gateway routes over IPv6 -> Studio must
+  # listen on '::' (dual-stack), otherwise 503. (0.0.0.0 = IPv4 only = unreachable.)
   HOST_BIND="${STUDIO_HOST:-::}"
   NET_OPTS=(--no-secure -H "${HOST_BIND}" -p "${PORT}")
-  echo "[entrypoint] Mode gateway : Studio ecoute sur [${HOST_BIND}]:${PORT} (--no-secure, IPv6)"
-  echo "[entrypoint] -> expose via SaladCloud Container Gateway (port ${PORT})."
+  echo "[entrypoint] Gateway mode: Studio listening on [${HOST_BIND}]:${PORT} (--no-secure, IPv6)"
+  echo "[entrypoint] -> exposed via the SaladCloud Container Gateway (port ${PORT})."
 else
   NET_OPTS=(-p "${PORT}" --secure)
-  echo "[entrypoint] Mode cloudflare : l'URL *.trycloudflare.com apparaitra ci-dessous."
-  echo "[entrypoint]   (NB: --secure echoue souvent sur SaladCloud -> prefere EXPOSE_MODE=gateway)"
+  echo "[entrypoint] Cloudflare mode: the *.trycloudflare.com URL will appear below."
+  echo "[entrypoint]   (NB: --secure often fails on SaladCloud -> prefer EXPOSE_MODE=gateway)"
 fi
 
-echo "[entrypoint] Lancement d'Unsloth Studio (mot de passe via UNSLOTH_STUDIO_PASSWORD)..."
+echo "[entrypoint] Starting Unsloth Studio (password via UNSLOTH_STUDIO_PASSWORD)..."
 exec "${UNS}" studio "${NET_OPTS[@]}"

--- a/recipes/unsloth-studio/entrypoint.sh
+++ b/recipes/unsloth-studio/entrypoint.sh
@@ -23,10 +23,29 @@ UNS="/root/.unsloth/studio/unsloth_studio/bin/unsloth"
 # 1er demarrage ; ensuite l'utilisateur peut le changer dans l'UI.
 export UNSLOTH_STUDIO_PASSWORD="${PASS}"
 
-# Moteur GGUF (llama.cpp) : le binaire llama-server n'a pas de rpath vers ses
-# propres libs (libllama-server-impl.so, libggml*.so...) -> "llama-server failed
-# to start". On ajoute son dossier de libs a LD_LIBRARY_PATH pour qu'il demarre.
-export LD_LIBRARY_PATH="/root/.unsloth/llama.cpp/build/bin:${LD_LIBRARY_PATH:-}"
+# Moteur GGUF (llama.cpp) sur GPU :
+#  - llama-server n'a pas de rpath vers ses propres libs (libllama-server-impl.so,
+#    libggml*.so) -> il faut son dossier de libs sur le path.
+#  - la build CUDA (libggml-cuda.so) a besoin des libs runtime CUDA de torch
+#    (libcudart, libcublas, libnvrtc) -> on ajoute aussi ces dossiers.
+_NVLIB="/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia"
+export LD_LIBRARY_PATH="/root/.unsloth/llama.cpp/build/bin:${_NVLIB}/cuda_runtime/lib:${_NVLIB}/cublas/lib:${_NVLIB}/cuda_nvrtc/lib:${LD_LIBRARY_PATH:-}"
+
+# GGUF accelere GPU : l'image embarque un llama.cpp CPU (build sans GPU au CI).
+# Au 1er boot (le GPU reel est present -> resolution correcte, download GitHub OK
+# depuis Salad), on installe la build CUDA prebuilt d'Unsloth. Idempotent (skip
+# si deja a jour). En tache de fond pour ne pas retarder Studio ; le build CPU
+# sert en attendant, puis un swap atomique bascule sur la build GPU.
+_STUDIO_PY="/root/.unsloth/studio/unsloth_studio/bin/python"
+_LC_INSTALLER="/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/studio/install_llama_prebuilt.py"
+if [ -x "${_STUDIO_PY}" ] && [ -f "${_LC_INSTALLER}" ]; then
+  echo "[entrypoint] Installation llama.cpp CUDA (GGUF GPU) en tache de fond..."
+  (
+    "${_STUDIO_PY}" "${_LC_INSTALLER}" --install-dir /root/.unsloth/llama.cpp \
+      && echo "[entrypoint] llama.cpp CUDA pret (GGUF accelere GPU)." \
+      || echo "[entrypoint] install llama.cpp CUDA echouee -> GGUF reste en CPU."
+  ) > /root/llama_cuda_install.log 2>&1 &
+fi
 
 # Login HF optionnel (permet de sauvegarder tes LoRA hors de la box)
 if [ -n "${HF_TOKEN:-}" ]; then

--- a/recipes/unsloth-studio/entrypoint.sh
+++ b/recipes/unsloth-studio/entrypoint.sh
@@ -23,6 +23,11 @@ UNS="/root/.unsloth/studio/unsloth_studio/bin/unsloth"
 # 1er demarrage ; ensuite l'utilisateur peut le changer dans l'UI.
 export UNSLOTH_STUDIO_PASSWORD="${PASS}"
 
+# Moteur GGUF (llama.cpp) : le binaire llama-server n'a pas de rpath vers ses
+# propres libs (libllama-server-impl.so, libggml*.so...) -> "llama-server failed
+# to start". On ajoute son dossier de libs a LD_LIBRARY_PATH pour qu'il demarre.
+export LD_LIBRARY_PATH="/root/.unsloth/llama.cpp/build/bin:${LD_LIBRARY_PATH:-}"
+
 # Login HF optionnel (permet de sauvegarder tes LoRA hors de la box)
 if [ -n "${HF_TOKEN:-}" ]; then
   echo "[entrypoint] Login Hugging Face..."

--- a/recipes/unsloth-studio/entrypoint.sh
+++ b/recipes/unsloth-studio/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Entrypoint SaladCloud pour Unsloth Studio
+# ---------------------------------------------------------------------------
+# Variables d'environnement (a definir dans le container group SaladCloud) :
+#   UNSLOTH_PASSWORD  mot de passe admin du Studio          (defaut: change-me-please)
+#   STUDIO_PORT       port web interne                       (defaut: 8080)
+#   EXPOSE_MODE       "cloudflare" -> URL publique *.trycloudflare.com (dans les logs)
+#                     "gateway"    -> ecoute sur '::' (IPv6/dual-stack), a exposer
+#                                     via SaladCloud Container Gateway
+#                     (defaut: cloudflare)
+#   HF_TOKEN          (optionnel) login Hugging Face -> push/pull de modeles
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+PASS="${UNSLOTH_PASSWORD:-change-me-please}"
+PORT="${STUDIO_PORT:-8080}"
+MODE="${EXPOSE_MODE:-cloudflare}"
+UNS="/root/.unsloth/studio/unsloth_studio/bin/unsloth"
+
+# Definition NON-INTERACTIVE du mot de passe admin (evite le prompt "New
+# password:" qui bloque un conteneur headless). Studio lit cette variable au
+# 1er demarrage ; ensuite l'utilisateur peut le changer dans l'UI.
+export UNSLOTH_STUDIO_PASSWORD="${PASS}"
+
+# Login HF optionnel (permet de sauvegarder tes LoRA hors de la box)
+if [ -n "${HF_TOKEN:-}" ]; then
+  echo "[entrypoint] Login Hugging Face..."
+  /root/.unsloth/studio/unsloth_studio/bin/huggingface-cli login --token "${HF_TOKEN}" || \
+    echo "[entrypoint] (login HF ignore)"
+fi
+
+# Diagnostic GPU (le "no GPU backend available" vient-il du conteneur ou de Studio ?)
+echo "[entrypoint] GPU check (nvidia-smi):"
+nvidia-smi -L 2>&1 | head -2 || echo "[entrypoint]   nvidia-smi indisponible (pas de GPU expose au conteneur ?)"
+
+# Options reseau selon le mode d'exposition
+if [ "${MODE}" = "gateway" ]; then
+  # --secure (tunnel Cloudflare) echoue depuis un conteneur SaladCloud (sortie
+  # cloudflared bloquee) -> on utilise --no-secure.
+  # IMPORTANT: le SaladCloud Container Gateway route en IPv6 -> il faut ecouter
+  # sur '::' (dual-stack), sinon 503. (0.0.0.0 = IPv4 seul = injoignable.)
+  HOST_BIND="${STUDIO_HOST:-::}"
+  NET_OPTS=(--no-secure -H "${HOST_BIND}" -p "${PORT}")
+  echo "[entrypoint] Mode gateway : Studio ecoute sur [${HOST_BIND}]:${PORT} (--no-secure, IPv6)"
+  echo "[entrypoint] -> expose via SaladCloud Container Gateway (port ${PORT})."
+else
+  NET_OPTS=(-p "${PORT}" --secure)
+  echo "[entrypoint] Mode cloudflare : l'URL *.trycloudflare.com apparaitra ci-dessous."
+  echo "[entrypoint]   (NB: --secure echoue souvent sur SaladCloud -> prefere EXPOSE_MODE=gateway)"
+fi
+
+echo "[entrypoint] Lancement d'Unsloth Studio (mot de passe via UNSLOTH_STUDIO_PASSWORD)..."
+exec "${UNS}" studio "${NET_OPTS[@]}"

--- a/recipes/unsloth-studio/entrypoint.sh
+++ b/recipes/unsloth-studio/entrypoint.sh
@@ -32,18 +32,36 @@ _NVLIB="/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia
 export LD_LIBRARY_PATH="/root/.unsloth/llama.cpp/build/bin:${_NVLIB}/cuda_runtime/lib:${_NVLIB}/cublas/lib:${_NVLIB}/cuda_nvrtc/lib:${LD_LIBRARY_PATH:-}"
 
 # GGUF accelere GPU : l'image embarque un llama.cpp CPU (build sans GPU au CI).
-# Au 1er boot (le GPU reel est present -> resolution correcte, download GitHub OK
-# depuis Salad), on installe la build CUDA prebuilt d'Unsloth. Idempotent (skip
-# si deja a jour). En tache de fond pour ne pas retarder Studio ; le build CPU
-# sert en attendant, puis un swap atomique bascule sur la build GPU.
+# Au 1er boot (GPU reel present -> resolution correcte, download GitHub OK depuis
+# Salad) on installe la build CUDA prebuilt d'Unsloth.
+# IMPORTANT : l'installeur, lance sur un dossier existant, le SUPPRIME parfois
+# sans reinstaller (1er passage) -> on installe dans un dossier TEMPORAIRE, et on
+# ne remplace le llama.cpp CPU (qui sert le GGUF en attendant) que si la build
+# CUDA est validee (swap atomique). Aucune fenetre "runtime not installed".
 _STUDIO_PY="/root/.unsloth/studio/unsloth_studio/bin/python"
 _LC_INSTALLER="/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/studio/install_llama_prebuilt.py"
+_LC_DIR="/root/.unsloth/llama.cpp"
+_LC_TMP="/root/.unsloth/llama.cpp.cuda"
 if [ -x "${_STUDIO_PY}" ] && [ -f "${_LC_INSTALLER}" ]; then
   echo "[entrypoint] Installation llama.cpp CUDA (GGUF GPU) en tache de fond..."
   (
-    "${_STUDIO_PY}" "${_LC_INSTALLER}" --install-dir /root/.unsloth/llama.cpp \
-      && echo "[entrypoint] llama.cpp CUDA pret (GGUF accelere GPU)." \
-      || echo "[entrypoint] install llama.cpp CUDA echouee -> GGUF reste en CPU."
+    ok=0
+    for attempt in 1 2 3; do
+      rm -rf "${_LC_TMP}"
+      if "${_STUDIO_PY}" "${_LC_INSTALLER}" --install-dir "${_LC_TMP}" \
+           && [ -f "${_LC_TMP}/build/bin/libggml-cuda.so" ]; then
+        ok=1; break
+      fi
+      echo "[entrypoint] tentative ${attempt} echouee, retry..."; sleep 5
+    done
+    if [ "${ok}" = "1" ]; then
+      rm -rf "${_LC_DIR}" && mv "${_LC_TMP}" "${_LC_DIR}"
+      ldconfig 2>/dev/null || true
+      echo "[entrypoint] llama.cpp CUDA pret (GGUF accelere GPU)."
+    else
+      rm -rf "${_LC_TMP}"
+      echo "[entrypoint] install llama.cpp CUDA echouee -> GGUF reste en CPU."
+    fi
   ) > /root/llama_cuda_install.log 2>&1 &
 fi
 

--- a/recipes/unsloth-studio/form.description.mdx
+++ b/recipes/unsloth-studio/form.description.mdx
@@ -1,0 +1,11 @@
+Deploy **Unsloth Studio** — a no-code web UI to fine-tune, run and export open
+LLMs (Gemma, Qwen, Llama, DeepSeek, gpt-oss…) on a SaladCloud GPU.
+
+Everything (PyTorch, CUDA, Unsloth) is baked into the image, so the node is
+ready as soon as it starts — and stays ready across reallocations. The web UI is
+exposed through the **SaladCloud Container Gateway**, giving you a stable HTTPS
+URL (no Cloudflare quick tunnels).
+
+You'll set an admin password for the Studio UI. Optionally provide a Hugging
+Face token to pull gated models and push your trained models to the Hub so your
+work is never lost when a node is recycled.

--- a/recipes/unsloth-studio/form.json
+++ b/recipes/unsloth-studio/form.json
@@ -24,11 +24,10 @@
     },
     "container_environment_hf_token": {
       "title": "HuggingFace Token (optional)",
-      "description": "Optional. Lets Studio pull gated models and push your trained LoRA/models to the Hub so they survive node reallocation. Must begin with \"hf_\" or \"api_org_\".",
+      "description": "Optional. Lets Studio pull gated models and push your trained LoRA/models to the Hub so they survive node reallocation. Must begin with \"hf_\" or \"api_org_\". Leave empty to skip.",
       "type": "string",
       "maxLength": 42,
-      "minLength": 37,
-      "pattern": "^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
+      "pattern": "^$|^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
     }
   }
 }

--- a/recipes/unsloth-studio/form.json
+++ b/recipes/unsloth-studio/form.json
@@ -1,0 +1,34 @@
+{
+  "title": "Unsloth Studio",
+  "description": "$replace",
+  "type": "object",
+  "required": [
+    "container_group_name",
+    "container_environment_unsloth_password"
+  ],
+  "properties": {
+    "container_group_name": {
+      "title": "Container Group Name",
+      "description": "Required* Must be 2-63 characters: lowercase letters, numbers, or hyphens. Cannot start with a number or start/end with a hyphen.",
+      "type": "string",
+      "maxLength": 63,
+      "minLength": 2,
+      "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$"
+    },
+    "container_environment_unsloth_password": {
+      "title": "Studio Admin Password",
+      "description": "Required* Password to log into the Unsloth Studio web UI. Choose a strong one - the UI can run code on the machine.",
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 128
+    },
+    "container_environment_hf_token": {
+      "title": "HuggingFace Token (optional)",
+      "description": "Optional. Lets Studio pull gated models and push your trained LoRA/models to the Hub so they survive node reallocation. Must begin with \"hf_\" or \"api_org_\".",
+      "type": "string",
+      "maxLength": 42,
+      "minLength": 37,
+      "pattern": "^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
+    }
+  }
+}

--- a/recipes/unsloth-studio/misc.json
+++ b/recipes/unsloth-studio/misc.json
@@ -1,0 +1,15 @@
+{
+  "ui": {
+    "container_environment_unsloth_password": {
+      "ui:widget": "password"
+    },
+    "container_environment_hf_token": {
+      "ui:widget": "password"
+    }
+  },
+  "documentation_url": "https://unsloth.ai/docs/new/studio",
+  "short_description": "Run Unsloth Studio - a no-code web UI to fine-tune, run and export open LLMs (Gemma, Qwen, Llama, gpt-oss) on a SaladCloud GPU.",
+  "workload_types": [
+    "LLM"
+  ]
+}

--- a/recipes/unsloth-studio/patches.json
+++ b/recipes/unsloth-studio/patches.json
@@ -1,0 +1,40 @@
+[
+  [
+    {
+      "op": "copy",
+      "from": "/input/autostart_policy",
+      "path": "/output/autostartPolicy"
+    },
+    {
+      "op": "copy",
+      "from": "/input/replicas",
+      "path": "/output/replicas"
+    },
+    {
+      "op": "copy",
+      "from": "/input/container_group_name",
+      "path": "/output/name"
+    },
+    {
+      "op": "copy",
+      "from": "/input/container_environment_unsloth_password",
+      "path": "/output/container/environmentVariables/UNSLOTH_PASSWORD"
+    },
+    {
+      "op": "copy",
+      "from": "/input/container_environment_hf_token",
+      "path": "/output/container/environmentVariables/HF_TOKEN"
+    }
+  ],
+  [
+    {
+      "op": "test",
+      "path": "/input/container_environment_hf_token",
+      "value": ""
+    },
+    {
+      "op": "remove",
+      "path": "/output/container/environmentVariables/HF_TOKEN"
+    }
+  ]
+]

--- a/recipes/unsloth-studio/patches.json
+++ b/recipes/unsloth-studio/patches.json
@@ -25,16 +25,5 @@
       "from": "/input/container_environment_hf_token",
       "path": "/output/container/environmentVariables/HF_TOKEN"
     }
-  ],
-  [
-    {
-      "op": "test",
-      "path": "/input/container_environment_hf_token",
-      "value": ""
-    },
-    {
-      "op": "remove",
-      "path": "/output/container/environmentVariables/HF_TOKEN"
-    }
   ]
 ]

--- a/recipes/unsloth-studio/recipe.json
+++ b/recipes/unsloth-studio/recipe.json
@@ -6,7 +6,8 @@
       "command": [],
       "environmentVariables": {
         "EXPOSE_MODE": "gateway",
-        "STUDIO_PORT": "8080"
+        "STUDIO_PORT": "8080",
+        "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin"
       },
       "image": "volkobfq/unsloth-studio@sha256:23d88a29daf2e6acb05aa6872c1a71996ffe9a24b761624b507418f514de7750",
       "imageCaching": false,

--- a/recipes/unsloth-studio/recipe.json
+++ b/recipes/unsloth-studio/recipe.json
@@ -9,7 +9,7 @@
         "STUDIO_PORT": "8080",
         "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_runtime/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cublas/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_nvrtc/lib"
       },
-      "image": "volkobfq/unsloth-studio@sha256:4630bc2d37518775af741c34f53183c729709225f34cbb9dc81d1fab52092c7f",
+      "image": "volkobfq/unsloth-studio@sha256:da6347e54d71fc6b1e6475363b08efdfd6351ec74201fb1930f54ced0e264df6",
       "imageCaching": false,
       "resources": {
         "cpu": 8,
@@ -69,11 +69,10 @@
       },
       "container_environment_hf_token": {
         "title": "HuggingFace Token (optional)",
-        "description": "Optional. Lets Studio pull gated models and push your trained LoRA/models to the Hub so they survive node reallocation. Must begin with \"hf_\" or \"api_org_\".",
+        "description": "Optional. Lets Studio pull gated models and push your trained LoRA/models to the Hub so they survive node reallocation. Must begin with \"hf_\" or \"api_org_\". Leave empty to skip.",
         "type": "string",
         "maxLength": 42,
-        "minLength": 37,
-        "pattern": "^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
+        "pattern": "^$|^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
       }
     }
   },
@@ -102,17 +101,6 @@
       {
         "op": "copy",
         "from": "/input/container_environment_hf_token",
-        "path": "/output/container/environmentVariables/HF_TOKEN"
-      }
-    ],
-    [
-      {
-        "op": "test",
-        "path": "/input/container_environment_hf_token",
-        "value": ""
-      },
-      {
-        "op": "remove",
         "path": "/output/container/environmentVariables/HF_TOKEN"
       }
     ]

--- a/recipes/unsloth-studio/recipe.json
+++ b/recipes/unsloth-studio/recipe.json
@@ -7,9 +7,9 @@
       "environmentVariables": {
         "EXPOSE_MODE": "gateway",
         "STUDIO_PORT": "8080",
-        "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin"
+        "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_runtime/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cublas/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_nvrtc/lib"
       },
-      "image": "volkobfq/unsloth-studio@sha256:23d88a29daf2e6acb05aa6872c1a71996ffe9a24b761624b507418f514de7750",
+      "image": "volkobfq/unsloth-studio@sha256:c6b8ac1b0a01301ef9ec2500cf00c4675089eaa289d0ab2af37d35a64c6d614c",
       "imageCaching": false,
       "resources": {
         "cpu": 8,

--- a/recipes/unsloth-studio/recipe.json
+++ b/recipes/unsloth-studio/recipe.json
@@ -1,0 +1,130 @@
+{
+  "container_template": {
+    "name": "",
+    "readme": "## Your Unsloth Studio is deploying 🦥\n\nIt can take a few minutes for a node to be allocated, pull the image and start.\n\n### 1. Open the Studio\n\nOnce the container group is **Running**, open the **Access Domain Name** shown in\nthe SaladCloud Portal (Container Gateway URL). That's your Studio.\n\n### 2. Authentication\n\n- **Container Gateway auth** (if you enabled it): requests need a SaladCloud API\n  key. The Portal preview handles this for you; for direct browser access, keep\n  it disabled or use an authenticated client.\n- **Studio password**: log in with the **admin password** you set in the form.\n\n### 3. Fine-tune & run\n\nUse the **Entraîner / Train** tab to fine-tune a model, and the **Chat** tab to\ntest the base vs. fine-tuned model side by side.\n\n### ⚠️ Persist your work\n\nSaladCloud nodes are ephemeral — if a node is reallocated, anything written only\nto local disk is lost. To keep your trained models:\n\n- Provide a **Hugging Face token** and **push/export** your model to the Hub from\n  the Studio **Export** tab, **or**\n- Download your artifacts before stopping the group.\n\nThe image itself (Unsloth + PyTorch) is baked in, so a recycled node comes back\nready without any reinstall.\n\n### Notes\n\n- The image already removes `flash_attn` so inference uses `sdpa`, avoiding the\n  `static cache is not compatible with flash_attention_2` error on Nemotron /\n  Gemma-3 style models.\n- Default GPU class is high-VRAM. Adjust CPU / RAM / GPU class in the form or the\n  container group settings to fit the models you train.\n",
+    "container": {
+      "command": [],
+      "environmentVariables": {
+        "EXPOSE_MODE": "gateway",
+        "STUDIO_PORT": "8080"
+      },
+      "image": "volkobfq/unsloth-studio@sha256:23d88a29daf2e6acb05aa6872c1a71996ffe9a24b761624b507418f514de7750",
+      "imageCaching": false,
+      "resources": {
+        "cpu": 8,
+        "memory": 24576,
+        "gpuClasses": ["ed563892-aacd-40f5-80b7-90c9be6c759b"],
+        "storageAmount": 107374182400,
+        "shmSize": 4096
+      },
+      "priority": "high"
+    },
+    "autostartPolicy": true,
+    "restartPolicy": "always",
+    "replicas": 1,
+    "networking": {
+      "auth": false,
+      "clientRequestTimeout": 100000,
+      "loadBalancer": "least_number_of_connections",
+      "port": 8080,
+      "protocol": "http",
+      "serverResponseTimeout": 100000,
+      "singleConnectionLimit": false
+    },
+    "readinessProbe": {
+      "failureThreshold": 20,
+      "http": {
+        "headers": [],
+        "path": "/",
+        "port": 8080,
+        "scheme": "http"
+      },
+      "initialDelaySeconds": 30,
+      "periodSeconds": 15,
+      "successThreshold": 1,
+      "timeoutSeconds": 5
+    }
+  },
+  "form": {
+    "title": "Unsloth Studio",
+    "description": "Deploy **Unsloth Studio** — a no-code web UI to fine-tune, run and export open\nLLMs (Gemma, Qwen, Llama, DeepSeek, gpt-oss…) on a SaladCloud GPU.\n\nEverything (PyTorch, CUDA, Unsloth) is baked into the image, so the node is\nready as soon as it starts — and stays ready across reallocations. The web UI is\nexposed through the **SaladCloud Container Gateway**, giving you a stable HTTPS\nURL (no Cloudflare quick tunnels).\n\nYou'll set an admin password for the Studio UI. Optionally provide a Hugging\nFace token to pull gated models and push your trained models to the Hub so your\nwork is never lost when a node is recycled.\n",
+    "type": "object",
+    "required": ["container_group_name", "container_environment_unsloth_password"],
+    "properties": {
+      "container_group_name": {
+        "title": "Container Group Name",
+        "description": "Required* Must be 2-63 characters: lowercase letters, numbers, or hyphens. Cannot start with a number or start/end with a hyphen.",
+        "type": "string",
+        "maxLength": 63,
+        "minLength": 2,
+        "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$"
+      },
+      "container_environment_unsloth_password": {
+        "title": "Studio Admin Password",
+        "description": "Required* Password to log into the Unsloth Studio web UI. Choose a strong one - the UI can run code on the machine.",
+        "type": "string",
+        "minLength": 8,
+        "maxLength": 128
+      },
+      "container_environment_hf_token": {
+        "title": "HuggingFace Token (optional)",
+        "description": "Optional. Lets Studio pull gated models and push your trained LoRA/models to the Hub so they survive node reallocation. Must begin with \"hf_\" or \"api_org_\".",
+        "type": "string",
+        "maxLength": 42,
+        "minLength": 37,
+        "pattern": "^(?:hf_|api_org_)[a-zA-Z0-9]{34}$"
+      }
+    }
+  },
+  "patches": [
+    [
+      {
+        "op": "copy",
+        "from": "/input/autostart_policy",
+        "path": "/output/autostartPolicy"
+      },
+      {
+        "op": "copy",
+        "from": "/input/replicas",
+        "path": "/output/replicas"
+      },
+      {
+        "op": "copy",
+        "from": "/input/container_group_name",
+        "path": "/output/name"
+      },
+      {
+        "op": "copy",
+        "from": "/input/container_environment_unsloth_password",
+        "path": "/output/container/environmentVariables/UNSLOTH_PASSWORD"
+      },
+      {
+        "op": "copy",
+        "from": "/input/container_environment_hf_token",
+        "path": "/output/container/environmentVariables/HF_TOKEN"
+      }
+    ],
+    [
+      {
+        "op": "test",
+        "path": "/input/container_environment_hf_token",
+        "value": ""
+      },
+      {
+        "op": "remove",
+        "path": "/output/container/environmentVariables/HF_TOKEN"
+      }
+    ]
+  ],
+  "ui": {
+    "container_environment_unsloth_password": {
+      "ui:widget": "password"
+    },
+    "container_environment_hf_token": {
+      "ui:widget": "password"
+    }
+  },
+  "documentation_url": "https://unsloth.ai/docs/new/studio",
+  "short_description": "Run Unsloth Studio - a no-code web UI to fine-tune, run and export open LLMs (Gemma, Qwen, Llama, gpt-oss) on a SaladCloud GPU.",
+  "workload_types": ["LLM"]
+}

--- a/recipes/unsloth-studio/recipe.json
+++ b/recipes/unsloth-studio/recipe.json
@@ -9,7 +9,7 @@
         "STUDIO_PORT": "8080",
         "LD_LIBRARY_PATH": "/root/.unsloth/llama.cpp/build/bin:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_runtime/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cublas/lib:/root/.unsloth/studio/unsloth_studio/lib/python3.13/site-packages/nvidia/cuda_nvrtc/lib"
       },
-      "image": "volkobfq/unsloth-studio@sha256:c6b8ac1b0a01301ef9ec2500cf00c4675089eaa289d0ab2af37d35a64c6d614c",
+      "image": "volkobfq/unsloth-studio@sha256:4630bc2d37518775af741c34f53183c729709225f34cbb9dc81d1fab52092c7f",
       "imageCaching": false,
       "resources": {
         "cpu": 8,

--- a/recipes/unsloth-studio/recipe.json
+++ b/recipes/unsloth-studio/recipe.json
@@ -13,7 +13,7 @@
       "resources": {
         "cpu": 8,
         "memory": 24576,
-        "gpuClasses": ["ed563892-aacd-40f5-80b7-90c9be6c759b"],
+        "gpuClasses": ["851399fb-7329-4195-a042-d6514b28cf33"],
         "storageAmount": 107374182400,
         "shmSize": 4096
       },


### PR DESCRIPTION
## Unsloth Studio recipe

Adds a recipe for **[Unsloth Studio](https://unsloth.ai/docs/new/studio)** — a no-code web UI to fine-tune, run and export open LLMs (Gemma, Qwen, Llama, DeepSeek, gpt-oss…) on a SaladCloud GPU.

### What it does
- Self-contained image with PyTorch (CUDA), Unsloth and Unsloth Studio baked in, so a reallocated node comes back ready with no reinstall.
- Exposed via **Container Gateway** (stable `*.salad.cloud` URL). Admin password is set non-interactively via `UNSLOTH_STUDIO_PASSWORD` (form field). Optional Hugging Face token to pull gated models and push trained models to the Hub.

### Deployment / testing
Tested end-to-end on SaladCloud (RTX 4090): container reaches **Running + Ready**, the Gateway URL opens Studio, login works, and the GPU is detected (`Hardware detected: CUDA -- NVIDIA GeForce RTX 4090`). Fine-tuning + chat compare tabs work.

### Notes for reviewers (Salad Gateway specifics handled)
- Studio listens on `::` (IPv6/dual-stack) — required by the Container Gateway (avoids 503).
- `readinessProbe` on `/` so traffic is only routed once Studio is up.
- Cloudflare `--secure` tunnel mode is intentionally **not** used (blocked from Salad containers); we use `--no-secure` + Gateway.
- Public image: `volkobfq/unsloth-studio` (pinned by digest for reproducibility).
- Inference fix baked in: `flash_attn` removed so Unsloth uses `sdpa` (avoids the static-cache/flash-attention-2 crash on Nemotron/Gemma-3 style models).

I'm reaching out to support@salad.com in parallel per the contribution guidelines. Happy to adjust GPU class, resources, docs, or image namespace as needed.
